### PR TITLE
feat(workspace): add collapsible session memory, copyable summary, and character change timeline

### DIFF
--- a/src/web/chat/service.py
+++ b/src/web/chat/service.py
@@ -437,6 +437,7 @@ class DialogueService:
         session["file_urls"] = self._build_file_urls(run_id, session)
         session["mode_display"] = self._mode_display(str(session.get("mode", "")).strip())
         session["transcript"] = self._serialize_transcript(session)
+        session["last_entry_preview"] = self._build_last_entry_preview(session)
         session["session_card"] = self._build_session_card(session)
         session["pending_turn_summary"] = self._build_pending_turn_summary(session)
         return session
@@ -499,6 +500,21 @@ class DialogueService:
             "participants": list(pending.get("participants", [])),
             "response_limit_hint": int(pending.get("response_limit_hint", 0) or 0),
         }
+
+    @staticmethod
+    def _build_last_entry_preview(session: dict[str, Any]) -> str:
+        history = list(session.get("history", []) or [])
+        for entry in reversed(history):
+            message = str(entry.get("message", "")).strip()
+            if not message:
+                continue
+            normalized = " ".join(message.split())
+            return normalized[:180]
+        pending = dict(session.get("pending_turn", {}) or {})
+        pending_message = str(pending.get("transcript_message", "")).strip()
+        if pending_message:
+            return " ".join(pending_message.split())[:180]
+        return ""
 
     def _build_file_urls(self, run_id: str, session: dict[str, Any]) -> dict[str, str]:
         session_id = str(session.get("session_id", "")).strip()

--- a/src/web/chat/service.py
+++ b/src/web/chat/service.py
@@ -436,10 +436,12 @@ class DialogueService:
         session = dict(payload)
         session["file_urls"] = self._build_file_urls(run_id, session)
         session["mode_display"] = self._mode_display(str(session.get("mode", "")).strip())
-        session["transcript"] = self._serialize_transcript(session)
+        transcript = self._serialize_transcript(session)
+        session["transcript"] = transcript
         session["last_entry_preview"] = self._build_last_entry_preview(session)
         session["session_card"] = self._build_session_card(session)
         session["pending_turn_summary"] = self._build_pending_turn_summary(session)
+        session["session_memory_summary"] = self._build_session_memory_summary(session, transcript)
         return session
 
     def _serialize_transcript(self, session: dict[str, Any]) -> list[dict[str, Any]]:
@@ -500,6 +502,89 @@ class DialogueService:
             "participants": list(pending.get("participants", [])),
             "response_limit_hint": int(pending.get("response_limit_hint", 0) or 0),
         }
+
+    def _build_session_memory_summary(self, session: dict[str, Any], transcript: list[dict[str, Any]]) -> dict[str, str]:
+        mode = str(session.get("mode", "observe")).strip() or "observe"
+        mode_display = self._mode_display(mode)
+        participants = [str(item).strip() for item in session.get("participants", []) if str(item).strip()]
+        history = list(session.get("history", []) or [])
+
+        cast_speakers: list[str] = []
+        seen: set[str] = set()
+        for item in transcript:
+            if str(item.get("role", "")).strip() != "character":
+                continue
+            speaker = str(item.get("speaker", "")).strip()
+            if not speaker or speaker in seen:
+                continue
+            seen.add(speaker)
+            cast_speakers.append(speaker)
+
+        last_messages: list[str] = []
+        for item in history[-6:]:
+            text = str(item.get("message", "")).strip()
+            if not text:
+                continue
+            last_messages.append(self._trim_summary_text(text, 88))
+        last_messages = last_messages[-3:]
+
+        recap = "这局刚开场，回顾会在这里滚动更新。"
+        if last_messages:
+            recap = f"最近一拍：{' / '.join(last_messages)}"
+
+        cast = "人物发言次序会在这里收住。"
+        if cast_speakers:
+            suffix = "..." if len(cast_speakers) > 5 else ""
+            cast = f"当前主要在场：{'、'.join(cast_speakers[:5])}{suffix}"
+        elif participants:
+            cast = f"本局参与角色：{'、'.join(participants[:5])}{'...' if len(participants) > 5 else ''}"
+
+        if mode == "act":
+            controlled = str(session.get("controlled_character", "")).strip() or "该角色"
+            perspective = f"你正以「{controlled}」发言，其他人会按角色关系回应。"
+        elif mode == "insert":
+            self_insert = dict(session.get("self_insert", {}) or {})
+            self_name = str(self_insert.get("display_name", "")).strip() or "你"
+            identity = str(self_insert.get("scene_identity", "")).strip()
+            perspective = f"你以「{self_name}」入场（{identity}）。" if identity else f"你以「{self_name}」入场，直接参与这幕。"
+        else:
+            perspective = "你在旁观推进模式里，主要作用是推动局势进入下一拍。"
+
+        world = "当前局势里的动作与情绪线会在这里提醒你。"
+        for item in reversed(transcript):
+            role = str(item.get("role", "")).strip()
+            text = str(item.get("message", "")).strip()
+            if not text:
+                continue
+            if role in {"scene", "director"}:
+                world = self._trim_summary_text(text, 88)
+                break
+        if world == "当前局势里的动作与情绪线会在这里提醒你。":
+            for item in reversed(transcript):
+                role = str(item.get("role", "")).strip()
+                text = str(item.get("message", "")).strip()
+                if role == "character" and text:
+                    world = f"人物最新情绪线：{self._trim_summary_text(text, 78)}"
+                    break
+
+        return {
+            "mode": mode,
+            "mode_display": mode_display,
+            "recap": recap,
+            "cast": cast,
+            "perspective": perspective,
+            "world": world,
+            "updated_at": str(session.get("updated_at", "")).strip(),
+        }
+
+    @staticmethod
+    def _trim_summary_text(value: str, limit: int) -> str:
+        text = " ".join(str(value or "").split()).strip()
+        if not text:
+            return ""
+        if len(text) <= limit:
+            return text
+        return f"{text[:limit]}..."
 
     @staticmethod
     def _build_last_entry_preview(session: dict[str, Any]) -> str:

--- a/src/web/static/fragments/main-shell.html
+++ b/src/web/static/fragments/main-shell.html
@@ -4,6 +4,40 @@
 
     <div id="dialogue-detail" class="hidden chat-detail">
       <div id="chat-content" class="chat-content">
+        <section id="dialogue-memory" class="dialogue-memory hidden is-collapsed" aria-live="polite">
+          <div class="dialogue-memory-head">
+            <div class="dialogue-memory-head-title">
+              <strong>本局记忆</strong>
+              <button id="dialogue-memory-toggle-button" type="button" class="soft-button">展开</button>
+              <button id="dialogue-memory-copy-button" type="button" class="soft-button">复制摘要</button>
+            </div>
+            <small id="dialogue-memory-updated">刚刚更新</small>
+            <small id="dialogue-memory-copy-status" class="dialogue-memory-copy-status"></small>
+          </div>
+          <div id="dialogue-memory-body" class="dialogue-memory-body">
+            <div class="dialogue-memory-grid">
+              <article class="dialogue-memory-card">
+                <span>场景回顾</span>
+                <p id="dialogue-memory-recap">这局刚开场，回顾会在这里滚动更新。</p>
+              </article>
+              <article class="dialogue-memory-card">
+                <span>人物动向</span>
+                <p id="dialogue-memory-cast">人物发言次序会在这里收住。</p>
+              </article>
+              <article class="dialogue-memory-card">
+                <span>你的位置</span>
+                <p id="dialogue-memory-perspective">你当前的入场方式会在这里提示。</p>
+              </article>
+              <article class="dialogue-memory-card">
+                <span>世界状态提示</span>
+                <p id="dialogue-memory-world">当前局势里的动作与情绪线会在这里提醒你。</p>
+              </article>
+            </div>
+            <div class="dialogue-memory-meta">
+              <span id="dialogue-memory-mode" class="dialogue-memory-mode">模式：未入场</span>
+            </div>
+          </div>
+        </section>
         <div id="dialogue-transcript" class="transcript"></div>
       </div>
     </div>

--- a/src/web/static/fragments/workflow-strip.html
+++ b/src/web/static/fragments/workflow-strip.html
@@ -264,6 +264,7 @@
           <small>可以直接从这里接着说</small>
         </div>
         <div id="work-session-preview" class="work-session-preview"></div>
+        <button id="work-session-preview-toggle" type="button" class="soft-button hidden">展开全部</button>
         <p id="work-session-preview-empty" class="card-note hidden">还没有会话，随时可以从下方三种方式开局。</p>
         <div class="work-mode-shortcuts">
           <button id="quick-open-observe-button" type="button" class="soft-button">旁观此局</button>

--- a/src/web/static/fragments/workflow-strip.html
+++ b/src/web/static/fragments/workflow-strip.html
@@ -165,6 +165,18 @@
       </div>
     </section>
     <p id="detail-action-note" class="card-note hidden">这一卷还在整理中，先看进度继续往前走。</p>
+    <section id="work-overview-loading" class="work-overview-loading hidden" aria-hidden="true">
+      <div class="work-loading-line work-loading-line-lg"></div>
+      <div class="work-loading-grid">
+        <div class="work-loading-card"></div>
+        <div class="work-loading-card"></div>
+        <div class="work-loading-card"></div>
+      </div>
+      <div class="work-loading-grid work-loading-grid-2">
+        <div class="work-loading-card"></div>
+        <div class="work-loading-card"></div>
+      </div>
+    </section>
 
     <div class="work-overview-grid">
       <section class="detail-section work-overview-panel">

--- a/src/web/static/fragments/workflow-strip.html
+++ b/src/web/static/fragments/workflow-strip.html
@@ -173,6 +173,7 @@
             <p class="eyebrow">角色</p>
             <h4>这一卷里谁已经站稳了</h4>
           </div>
+          <button id="run-character-readiness-toggle" type="button" class="soft-button hidden">展开全部</button>
         </div>
         <p class="detail-section-copy">先看谁已站稳、谁还缺关键字段，再决定下一步补谁。</p>
         <div id="run-character-readiness" class="work-character-list"></div>

--- a/src/web/static/fragments/workflow-strip.html
+++ b/src/web/static/fragments/workflow-strip.html
@@ -431,6 +431,18 @@
       <div id="character-overview-trust-signals" class="character-overview-trust-signals"></div>
     </section>
 
+    <section class="detail-section">
+      <div class="detail-section-head">
+        <div>
+          <p class="eyebrow">改动时间线</p>
+          <h4>这一页最近怎样被写回过</h4>
+        </div>
+      </div>
+      <p class="detail-section-copy">这里按时间记录字段补全、手动保存和增量蒸馏写回，方便快速回看这份角色资产是怎么稳起来的。</p>
+      <div id="character-overview-change-timeline" class="character-overview-change-timeline"></div>
+      <p id="character-overview-change-timeline-empty" class="card-note hidden">还没有这位角色的改动记录，先补一次字段或继续增量蒸馏就会出现。</p>
+    </section>
+
     <div class="character-overview-grid">
       <section class="detail-section">
         <div class="detail-section-head">

--- a/src/web/static/fragments/workflow-strip.html
+++ b/src/web/static/fragments/workflow-strip.html
@@ -263,6 +263,9 @@
           <strong>最近会话</strong>
           <small>可以直接从这里接着说</small>
         </div>
+        <div id="work-session-resume-shell" class="card-actions hidden">
+          <button id="work-session-resume-latest-button" type="button" class="soft-button">继续最近一局</button>
+        </div>
         <div id="work-session-preview" class="work-session-preview"></div>
         <button id="work-session-preview-toggle" type="button" class="soft-button hidden">展开全部</button>
         <p id="work-session-preview-empty" class="card-note hidden">还没有会话，随时可以从下方三种方式开局。</p>

--- a/src/web/static/js/core.js
+++ b/src/web/static/js/core.js
@@ -27,6 +27,7 @@ var newRunFlowOpen = false;
 var redistillPanelOpen = false;
 var sourceHistoryExpanded = false;
 var characterReadinessExpanded = false;
+var workSessionPreviewExpanded = false;
 var characterOverviewOpen = false;
 var currentCharacterOverview = null;
 var currentPersonaReview = null;

--- a/src/web/static/js/core.js
+++ b/src/web/static/js/core.js
@@ -26,6 +26,7 @@ var chatModePickerOpen = false;
 var newRunFlowOpen = false;
 var redistillPanelOpen = false;
 var sourceHistoryExpanded = false;
+var characterReadinessExpanded = false;
 var characterOverviewOpen = false;
 var currentCharacterOverview = null;
 var currentPersonaReview = null;

--- a/src/web/static/js/core.js
+++ b/src/web/static/js/core.js
@@ -21,6 +21,7 @@ var sidebarCollapsed = false;
 var sessionBooting = false;
 var recentSessionsRequestId = 0;
 var recentSessionsCache = [];
+var recentSessionSnippets = new Map();
 var allRuns = [];
 var chatModePickerOpen = false;
 var newRunFlowOpen = false;
@@ -108,6 +109,23 @@ function joinCharacters(values) {
 
 function parseCharacters(value) {
   return uniq(String(value || "").split(/[\n,，、]+/));
+}
+
+function sessionSnippetKey(runId, sessionId) {
+  return `${String(runId || "").trim()}::${String(sessionId || "").trim()}`;
+}
+
+function rememberRecentSessionSnippet(runId, sessionId, message) {
+  const key = sessionSnippetKey(runId, sessionId);
+  const text = String(message || "").trim();
+  if (!key || !text) return;
+  recentSessionSnippets.set(key, text);
+}
+
+function readRecentSessionSnippet(runId, sessionId) {
+  const key = sessionSnippetKey(runId, sessionId);
+  if (!key) return "";
+  return String(recentSessionSnippets.get(key) || "").trim();
 }
 
 function applySidebarState() {

--- a/src/web/static/js/dialogue.js
+++ b/src/web/static/js/dialogue.js
@@ -145,9 +145,26 @@ function buildOptimisticTranscript(session, message) {
   return transcript;
 }
 
+function latestSessionSnippetFromTranscript(items) {
+  const rows = Array.isArray(items) ? items : [];
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const entry = rows[index] || {};
+    const role = String(entry.role || "").trim();
+    const message = String(entry.message || "").trim();
+    if (!message) continue;
+    if (role === "loading") continue;
+    return message;
+  }
+  return "";
+}
+
 async function renderDialogueSession(session) {
   currentDialogueSessionId = session.session_id || "";
   currentDialogueSession = session;
+  const latestSnippet = latestSessionSnippetFromTranscript(session?.transcript);
+  if (latestSnippet) {
+    rememberRecentSessionSnippet(currentRunId, currentDialogueSessionId, latestSnippet);
+  }
   sessionBooting = false;
   setComposerEnabled(true);
   if (typeof syncSuggestButtonVisibility === "function") {

--- a/src/web/static/js/dialogue.js
+++ b/src/web/static/js/dialogue.js
@@ -81,6 +81,193 @@ function renderDialogueTranscript(session) {
   renderTranscript(items);
 }
 
+function trimInlineMessage(value) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  return text.length > 88 ? `${text.slice(0, 88)}...` : text;
+}
+
+function buildDialogueMemorySnapshot(session) {
+  const summary = session?.session_memory_summary || {};
+  const summaryMode = String(summary.mode || "").trim();
+  const summaryModeLabel = String(summary.mode_display || "").trim();
+  const summaryRecap = String(summary.recap || "").trim();
+  const summaryCast = String(summary.cast || "").trim();
+  const summaryPerspective = String(summary.perspective || "").trim();
+  const summaryWorld = String(summary.world || "").trim();
+  const summaryUpdated = String(summary.updated_at || "").trim();
+
+  if (summaryRecap || summaryCast || summaryPerspective || summaryWorld) {
+    return {
+      modeLabel: summaryModeLabel || humanizeMode(summaryMode || session?.mode || session?.session_card?.mode || "observe"),
+      recap: summaryRecap || "这局刚开场，回顾会在这里滚动更新。",
+      cast: summaryCast || "人物发言次序会在这里收住。",
+      perspective: summaryPerspective || "你当前的入场方式会在这里提示。",
+      world: summaryWorld || "当前局势里的动作与情绪线会在这里提醒你。",
+      updated: formatWeakTime(summaryUpdated) || formatWeakTime(session?.updated_at) || "刚刚更新",
+    };
+  }
+
+  const mode = String(session?.mode || session?.session_card?.mode || "observe").trim() || "observe";
+  const modeLabel = humanizeMode(mode) || mode;
+  const transcript = Array.isArray(session?.transcript) ? session.transcript : [];
+  const castRows = transcript.filter((item) => item?.role === "character");
+  const worldRows = transcript.filter((item) => item?.role === "scene" || item?.role === "director");
+  const lastRows = transcript.slice(-6);
+  const lastCharacter = castRows.length ? castRows[castRows.length - 1] : null;
+  const lastWorld = worldRows.length ? worldRows[worldRows.length - 1] : null;
+  const speakerOrder = [];
+  const seen = new Set();
+  castRows.forEach((item) => {
+    const speaker = String(item?.speaker || "").trim();
+    if (!speaker || seen.has(speaker)) return;
+    seen.add(speaker);
+    speakerOrder.push(speaker);
+  });
+  const lastBeatMessages = lastRows
+    .filter((item) => String(item?.message || "").trim())
+    .map((item) => trimInlineMessage(item.message))
+    .slice(-3);
+
+  let recap = "这局刚开场，回顾会在这里滚动更新。";
+  if (lastBeatMessages.length) {
+    recap = `最近一拍：${lastBeatMessages.join(" / ")}`;
+  }
+
+  let cast = "人物发言次序会在这里收住。";
+  if (speakerOrder.length) {
+    cast = `当前主要在场：${speakerOrder.slice(0, 5).join("、")}${speakerOrder.length > 5 ? "..." : ""}`;
+  } else if (lastCharacter?.speaker) {
+    cast = `${lastCharacter.speaker} 刚刚接话：${trimInlineMessage(lastCharacter.message)}`;
+  }
+
+  let perspective = "你当前的入场方式会在这里提示。";
+  if (mode === "act") {
+    const controlled = String(session?.session_card?.controlled_character || "").trim() || "该角色";
+    perspective = `你正以「${controlled}」发言，其他人会按角色关系回应。`;
+  } else if (mode === "insert") {
+    const selfName = String(session?.session_card?.self_insert?.display_name || "").trim() || "你";
+    const identity = String(session?.session_card?.self_insert?.scene_identity || "").trim();
+    perspective = identity ? `你以「${selfName}」入场（${identity}）。` : `你以「${selfName}」入场，直接参与这幕。`;
+  } else {
+    perspective = "你在旁观推进模式里，主要作用是推动局势进入下一拍。";
+  }
+
+  let world = "当前局势里的动作与情绪线会在这里提醒你。";
+  if (lastWorld?.message) {
+    world = trimInlineMessage(lastWorld.message);
+  } else if (lastCharacter?.message) {
+    world = `人物最新情绪线：${trimInlineMessage(lastCharacter.message)}`;
+  }
+
+  return {
+    modeLabel,
+    recap,
+    cast,
+    perspective,
+    world,
+    updated: formatWeakTime(session?.updated_at) || "刚刚更新",
+  };
+}
+
+function renderDialogueMemory(session) {
+  const root = el("dialogue-memory");
+  if (!root) return;
+  if (!session) {
+    root.classList.add("hidden");
+    return;
+  }
+  const snapshot = buildDialogueMemorySnapshot(session);
+  const collapsed = root.classList.contains("is-collapsed");
+  root.classList.remove("hidden");
+  setText("dialogue-memory-recap", snapshot.recap, "");
+  setText("dialogue-memory-cast", snapshot.cast, "");
+  setText("dialogue-memory-perspective", snapshot.perspective, "");
+  setText("dialogue-memory-world", snapshot.world, "");
+  setText("dialogue-memory-mode", `模式：${snapshot.modeLabel}`, "");
+  setText("dialogue-memory-updated", `更新于 ${snapshot.updated}`, "");
+  const toggle = el("dialogue-memory-toggle-button");
+  if (toggle) {
+    toggle.textContent = collapsed ? "展开" : "收起";
+  }
+  const body = el("dialogue-memory-body");
+  if (body) {
+    body.classList.toggle("hidden", collapsed);
+  }
+}
+
+function buildDialogueMemoryClipboardText(session) {
+  if (!session) return "";
+  const snapshot = buildDialogueMemorySnapshot(session);
+  const participants = Array.isArray(session?.session_card?.participants) ? session.session_card.participants : [];
+  const participantText = participants.length ? joinCharacters(participants) : "未记录";
+  return [
+    `【本局记忆】`,
+    `模式：${snapshot.modeLabel}`,
+    `同席：${participantText}`,
+    `场景回顾：${snapshot.recap}`,
+    `人物动向：${snapshot.cast}`,
+    `你的位置：${snapshot.perspective}`,
+    `世界状态：${snapshot.world}`,
+    `更新时间：${snapshot.updated}`,
+  ].join("\n");
+}
+
+async function copyDialogueMemorySummary() {
+  if (!currentDialogueSession) return;
+  const button = el("dialogue-memory-copy-button");
+  const status = el("dialogue-memory-copy-status");
+  const original = button?.textContent || "复制摘要";
+  const text = buildDialogueMemoryClipboardText(currentDialogueSession);
+  if (!text) return;
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "readonly");
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.select();
+      const ok = document.execCommand("copy");
+      textarea.remove();
+      if (!ok) {
+        throw new Error("copy_failed");
+      }
+    }
+    if (button) {
+      button.textContent = "已复制";
+      window.setTimeout(() => {
+        if (button) button.textContent = original;
+      }, 1200);
+    }
+    if (status) status.textContent = "已复制";
+    window.setTimeout(() => {
+      if (status) status.textContent = "";
+    }, 1600);
+  } catch (_error) {
+    if (button) {
+      button.textContent = "复制失败";
+      window.setTimeout(() => {
+        if (button) button.textContent = original;
+      }, 1400);
+    }
+    if (status) status.textContent = "复制失败";
+    window.setTimeout(() => {
+      if (status) status.textContent = "";
+    }, 1600);
+  }
+}
+
+function toggleDialogueMemory() {
+  const root = el("dialogue-memory");
+  if (!root) return;
+  root.classList.toggle("is-collapsed");
+  renderDialogueMemory(currentDialogueSession);
+}
+
 function renderTranscript(items) {
   const root = el("dialogue-transcript");
   if (!root) return;
@@ -174,6 +361,7 @@ async function renderDialogueSession(session) {
     renderObserveQuickReplies(session);
   }
   setSessionBadge("对话中");
+  renderDialogueMemory(session);
   renderDialogueTranscript(session);
   await loadRecentSessions();
   updateWorkflowState();

--- a/src/web/static/js/main.js
+++ b/src/web/static/js/main.js
@@ -1210,6 +1210,16 @@ function bindEvents() {
   bind("delete-self-card-button", "click", handleDeleteSelfCard);
   bind("suggest-turn-button", "click", handleSuggestTurn);
   bind("prepare-turn-button", "click", handleSendTurn);
+  bind("dialogue-memory-copy-button", "click", () => {
+    if (typeof copyDialogueMemorySummary === "function") {
+      copyDialogueMemorySummary();
+    }
+  });
+  bind("dialogue-memory-toggle-button", "click", () => {
+    if (typeof toggleDialogueMemory === "function") {
+      toggleDialogueMemory();
+    }
+  });
 
   bind("dialogue-mode", "change", syncModeFields);
   bind("dialogue-self-card", "change", handleSelfCardSelectionChange);

--- a/src/web/static/js/main.js
+++ b/src/web/static/js/main.js
@@ -588,6 +588,34 @@ async function openPersonaReview() {
   await openPersonaReviewForCharacter("");
 }
 
+async function openWorkCharacterReview() {
+  if (!currentRunId || !currentRun) return;
+  const names = getRunCharacterNames(currentRun);
+  if (!names.length) {
+    setStatus("bookshelf-status", "这一卷里还没有可校对的人物。");
+    return;
+  }
+
+  let targetCharacter = "";
+  if (typeof buildWorkPriorityReviewItems === "function") {
+    const priority = buildWorkPriorityReviewItems(currentRun);
+    targetCharacter = String(priority?.[0]?.name || "").trim();
+  }
+  if (!targetCharacter) {
+    targetCharacter = names[0] || "";
+  }
+  if (!targetCharacter) {
+    setStatus("bookshelf-status", "这一卷里还没有可校对的人物。");
+    return;
+  }
+
+  if (typeof openCharacterOverview === "function") {
+    await openCharacterOverview(targetCharacter);
+    return;
+  }
+  await openPersonaReviewForCharacter(targetCharacter);
+}
+
 async function openQuickDialogueMode(mode) {
   await openNewDialogueSession();
   if (!currentRun || !el("dialogue-mode")) return;
@@ -1062,7 +1090,11 @@ function bindEvents() {
     openQuickDialogueMode("insert").catch((error) => setStatus("dialogue-session-status", error.message || "这一幕暂时没有铺开。"));
   });
   bind("detail-stop-run-button", "click", handleStopRun);
-  bind("open-persona-review-button", "click", openPersonaReview);
+  bind("open-persona-review-button", "click", () => {
+    openWorkCharacterReview().catch((error) => {
+      setStatus("bookshelf-status", error.message || "人物档案暂时没有载入。");
+    });
+  });
   bind("open-relation-details-button", "click", openRelationDetails);
   bind("detail-export-summary-button", "click", () => {
     if (typeof openWorkSummaryExport === "function") {

--- a/src/web/static/js/main.js
+++ b/src/web/static/js/main.js
@@ -1184,6 +1184,12 @@ function bindEvents() {
       renderCharacterReadiness(currentRun);
     }
   });
+  bind("work-session-preview-toggle", "click", () => {
+    workSessionPreviewExpanded = !workSessionPreviewExpanded;
+    if (currentRun) {
+      renderWorkSessionPreview(currentRun);
+    }
+  });
   bind("back-to-bookshelf-button", "click", showBookshelfHome);
   bind("back-to-detail-button", "click", () => {
     chatModePickerOpen = false;

--- a/src/web/static/js/main.js
+++ b/src/web/static/js/main.js
@@ -1146,6 +1146,12 @@ function bindEvents() {
       renderSourceHistory(currentRun);
     }
   });
+  bind("run-character-readiness-toggle", "click", () => {
+    characterReadinessExpanded = !characterReadinessExpanded;
+    if (currentRun) {
+      renderCharacterReadiness(currentRun);
+    }
+  });
   bind("back-to-bookshelf-button", "click", showBookshelfHome);
   bind("back-to-detail-button", "click", () => {
     chatModePickerOpen = false;

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -602,6 +602,7 @@ function renderWorkSessionPreview(run) {
   if (!root) return;
   root.innerHTML = "";
   const novelTitle = runNovelTitle(run);
+  const characterNames = getRunCharacterNames(run);
   const allSessions = (recentSessionsCache || [])
     .filter((item) => normalizeNovelTitle(item?.novel_id || "") === novelTitle)
     .sort((left, right) => String(right?.updated_at || "").localeCompare(String(left?.updated_at || "")));
@@ -626,10 +627,11 @@ function renderWorkSessionPreview(run) {
   visibleSessions.forEach((item) => {
     const button = document.createElement("button");
     button.type = "button";
-    button.className = "work-session-card";
-    const participantCount = Array.isArray(item.participants) ? item.participants.length : 0;
     const serverSnippet = String(item.last_entry_preview || "").trim();
     const snippet = serverSnippet || readRecentSessionSnippet(item.run_id, item.session_id);
+    const matchedCharacter = findMatchedSessionCharacter(snippet, characterNames);
+    button.className = `work-session-card${matchedCharacter ? " has-match" : ""}`;
+    const participantCount = Array.isArray(item.participants) ? item.participants.length : 0;
     button.innerHTML = `
       <div class="work-session-head">
         <div class="work-session-title">
@@ -637,6 +639,7 @@ function renderWorkSessionPreview(run) {
           <small>${item.mode_display || humanizeMode(item.mode) || "这一幕"} · ${participantCount || 0} 人</small>
         </div>
       </div>
+      ${matchedCharacter ? `<span class="work-session-match">命中 ${escapeHtml(matchedCharacter)}</span>` : ""}
       ${snippet ? `<p class="work-session-copy">${escapeHtml(snippet)}</p>` : ""}
       <div class="work-session-meta">
         <span>${formatWeakTime(item.updated_at) || "刚刚"}</span>
@@ -656,6 +659,15 @@ function renderWorkSessionPreview(run) {
   }
   root.classList.toggle("hidden", root.childElementCount === 0);
   toggle("work-session-preview-empty", root.childElementCount === 0);
+}
+
+function findMatchedSessionCharacter(snippet, characterNames) {
+  const text = String(snippet || "").trim();
+  if (!text) return "";
+  return (Array.isArray(characterNames) ? characterNames : []).find((name) => {
+    const candidate = String(name || "").trim();
+    return candidate && text.includes(candidate);
+  }) || "";
 }
 
 async function openWorkSessionFromPreviewItem(item) {

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -597,12 +597,32 @@ function setWorkGraphStatusBadge(text, tone = "warning") {
 function renderWorkSessionPreview(run) {
   const root = el("work-session-preview");
   const toggleButton = el("work-session-preview-toggle");
+  const resumeShell = el("work-session-resume-shell");
+  const resumeButton = el("work-session-resume-latest-button");
   if (!root) return;
   root.innerHTML = "";
   const novelTitle = runNovelTitle(run);
-  const allSessions = (recentSessionsCache || []).filter((item) => normalizeNovelTitle(item?.novel_id || "") === novelTitle);
+  const allSessions = (recentSessionsCache || [])
+    .filter((item) => normalizeNovelTitle(item?.novel_id || "") === novelTitle)
+    .sort((left, right) => String(right?.updated_at || "").localeCompare(String(left?.updated_at || "")));
   const canExpand = allSessions.length > 3;
   const visibleSessions = workSessionPreviewExpanded ? allSessions : allSessions.slice(0, 3);
+  if (resumeShell && resumeButton) {
+    const latest = allSessions[0] || null;
+    resumeShell.classList.toggle("hidden", !latest);
+    if (latest) {
+      const label = joinCharacters(latest.participants || []) || "最近会话";
+      resumeButton.textContent = `继续：${label}`;
+      resumeButton.onclick = () => {
+        openWorkSessionFromPreviewItem(latest).catch((error) => {
+          setStatus("dialogue-session-status", error.message || "这一幕暂时没有铺开。");
+        });
+      };
+    } else {
+      resumeButton.onclick = null;
+      resumeButton.textContent = "继续最近一局";
+    }
+  }
   visibleSessions.forEach((item) => {
     const button = document.createElement("button");
     button.type = "button";
@@ -620,21 +640,10 @@ function renderWorkSessionPreview(run) {
         <span>${humanizeSessionStatus(item.status)}</span>
       </div>
     `;
-    button.addEventListener("click", async () => {
-      currentRunId = item.run_id || currentRunId;
-      currentDialogueSessionId = item.session_id || "";
-      currentDialogueSession = null;
-      sessionBooting = true;
-      setComposerEnabled(false);
-      setSessionBadge("入场中");
-      renderSessionBooting(item.mode, item.participants || []);
-      updateWorkflowState();
-      const [freshRun, session] = await Promise.all([
-        apiJson(`/api/web/runs/${item.run_id}`),
-        apiJson(`/api/web/runs/${item.run_id}/dialogue/sessions/${item.session_id}`),
-      ]);
-      renderRun(freshRun, { preserveDialogue: true, suppressWorkflowUpdate: true });
-      await renderDialogueSession(session);
+    button.addEventListener("click", () => {
+      openWorkSessionFromPreviewItem(item).catch((error) => {
+        setStatus("dialogue-session-status", error.message || "这一幕暂时没有铺开。");
+      });
     });
     root.appendChild(button);
   });
@@ -644,6 +653,24 @@ function renderWorkSessionPreview(run) {
   }
   root.classList.toggle("hidden", root.childElementCount === 0);
   toggle("work-session-preview-empty", root.childElementCount === 0);
+}
+
+async function openWorkSessionFromPreviewItem(item) {
+  if (!item?.run_id || !item?.session_id) return;
+  currentRunId = item.run_id || currentRunId;
+  currentDialogueSessionId = item.session_id || "";
+  currentDialogueSession = null;
+  sessionBooting = true;
+  setComposerEnabled(false);
+  setSessionBadge("入场中");
+  renderSessionBooting(item.mode, item.participants || []);
+  updateWorkflowState();
+  const [freshRun, session] = await Promise.all([
+    apiJson(`/api/web/runs/${item.run_id}`),
+    apiJson(`/api/web/runs/${item.run_id}/dialogue/sessions/${item.session_id}`),
+  ]);
+  renderRun(freshRun, { preserveDialogue: true, suppressWorkflowUpdate: true });
+  await renderDialogueSession(session);
 }
 
 function openWorkSummaryExport() {

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -628,7 +628,8 @@ function renderWorkSessionPreview(run) {
     button.type = "button";
     button.className = "work-session-card";
     const participantCount = Array.isArray(item.participants) ? item.participants.length : 0;
-    const snippet = readRecentSessionSnippet(item.run_id, item.session_id);
+    const serverSnippet = String(item.last_entry_preview || "").trim();
+    const snippet = serverSnippet || readRecentSessionSnippet(item.run_id, item.session_id);
     button.innerHTML = `
       <div class="work-session-head">
         <div class="work-session-title">

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -431,10 +431,13 @@ function buildCharacterReadinessItems(run) {
 
 function renderCharacterReadiness(run) {
   const root = el("run-character-readiness");
+  const toggleButton = el("run-character-readiness-toggle");
   if (!root) return;
   root.innerHTML = "";
   const items = buildCharacterReadinessItems(run);
-  items.forEach((item) => {
+  const canExpand = items.length > 3;
+  const visibleItems = characterReadinessExpanded ? items : items.slice(0, 3);
+  visibleItems.forEach((item) => {
     const button = document.createElement("button");
     button.type = "button";
     button.className = "work-character-card";
@@ -459,6 +462,10 @@ function renderCharacterReadiness(run) {
     });
     root.appendChild(button);
   });
+  if (toggleButton) {
+    toggleButton.classList.toggle("hidden", !canExpand);
+    toggleButton.textContent = characterReadinessExpanded ? "收起部分" : "展开全部";
+  }
   root.classList.toggle("hidden", root.childElementCount === 0);
   toggle("run-character-readiness-empty", root.childElementCount === 0);
 }
@@ -1555,6 +1562,7 @@ function renderRun(run, options = {}) {
   currentCharacterOverview = null;
   redistillPanelOpen = false;
   sourceHistoryExpanded = false;
+  characterReadinessExpanded = false;
   runCreationPending = run.status === "running" && run.summary?.status_text !== "workflow_complete";
   renderRunSummary(run);
   renderRunEvents(run);

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -606,8 +606,16 @@ function renderWorkSessionPreview(run) {
   const allSessions = (recentSessionsCache || [])
     .filter((item) => normalizeNovelTitle(item?.novel_id || "") === novelTitle)
     .sort((left, right) => String(right?.updated_at || "").localeCompare(String(left?.updated_at || "")));
-  const canExpand = allSessions.length > 3;
-  const visibleSessions = workSessionPreviewExpanded ? allSessions : allSessions.slice(0, 3);
+  const rankedSessions = [...allSessions].sort((left, right) => {
+    const rightMatch = Boolean(findMatchedSessionCharacter(getSessionPreviewSnippet(right), characterNames));
+    const leftMatch = Boolean(findMatchedSessionCharacter(getSessionPreviewSnippet(left), characterNames));
+    if (rightMatch !== leftMatch) {
+      return Number(rightMatch) - Number(leftMatch);
+    }
+    return String(right?.updated_at || "").localeCompare(String(left?.updated_at || ""));
+  });
+  const canExpand = rankedSessions.length > 3;
+  const visibleSessions = workSessionPreviewExpanded ? rankedSessions : rankedSessions.slice(0, 3);
   if (resumeShell && resumeButton) {
     const latest = allSessions[0] || null;
     resumeShell.classList.toggle("hidden", !latest);
@@ -627,8 +635,7 @@ function renderWorkSessionPreview(run) {
   visibleSessions.forEach((item) => {
     const button = document.createElement("button");
     button.type = "button";
-    const serverSnippet = String(item.last_entry_preview || "").trim();
-    const snippet = serverSnippet || readRecentSessionSnippet(item.run_id, item.session_id);
+    const snippet = getSessionPreviewSnippet(item);
     const matchedCharacter = findMatchedSessionCharacter(snippet, characterNames);
     button.className = `work-session-card${matchedCharacter ? " has-match" : ""}`;
     const participantCount = Array.isArray(item.participants) ? item.participants.length : 0;
@@ -659,6 +666,11 @@ function renderWorkSessionPreview(run) {
   }
   root.classList.toggle("hidden", root.childElementCount === 0);
   toggle("work-session-preview-empty", root.childElementCount === 0);
+}
+
+function getSessionPreviewSnippet(item) {
+  const serverSnippet = String(item?.last_entry_preview || "").trim();
+  return serverSnippet || readRecentSessionSnippet(item?.run_id, item?.session_id);
 }
 
 function findMatchedSessionCharacter(snippet, characterNames) {

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -752,10 +752,66 @@ function renderCharacterOverview(payload) {
   renderCharacterOverviewHealthMetrics(snapshot);
   renderCharacterOverviewEvidenceMetrics(evidenceSnapshot);
   renderCharacterOverviewTrustSignals(payload, snapshot, evidenceSnapshot);
+  renderCharacterOverviewChangeTimeline(payload);
   renderCharacterOverviewKeyFields(fields);
   renderCharacterOverviewVoiceSummary(fields);
   renderCharacterOverviewRelationSummary(fields);
   renderCharacterOverviewAdvancedGroups(fields);
+}
+
+function buildCharacterOverviewChangeTimelineItems(character) {
+  const name = String(character || "").trim();
+  if (!name) return [];
+  const events = getCurrentRunEvents()
+    .filter((item) => String(item?.character || "").trim() === name && String(item?.stage || "").trim() === "persona_review_saved")
+    .slice()
+    .reverse();
+  return events.slice(0, 8).map((item) => {
+    const reviewSource = String(item?.review_source || "").trim();
+    const reviewNote = String(item?.review_note || "").trim();
+    const changedFields = Array.isArray(item?.changed_fields) ? item.changed_fields.filter(Boolean) : [];
+    const changedLabels = changedFields.map((field) => CHARACTER_OVERVIEW_FIELD_LABELS[field] || field).slice(0, 3);
+    let title = "字段已写回";
+    let badge = "手动校对";
+    let copy = String(item?.message || "").trim() || "这次改动已经写回这一卷。";
+    if (reviewSource === "character_overview_autofill") {
+      title = "AI补全已写回";
+      badge = formatCharacterOverviewAutofillSource(reviewNote);
+      copy = changedLabels.length ? `已补：${changedLabels.join("、")}。` : "AI 补全结果已写回。";
+    } else if (reviewSource === "character_overview_inline_edit") {
+      title = "手动改动已写回";
+      badge = "字段直改";
+      copy = changedLabels.length ? `你改了：${changedLabels.join("、")}。` : "手动改动已写回。";
+    }
+    return {
+      title,
+      badge,
+      copy,
+      updated: formatWeakTime(item?.timestamp || "") || "刚刚",
+    };
+  });
+}
+
+function renderCharacterOverviewChangeTimeline(payload) {
+  const root = el("character-overview-change-timeline");
+  if (!root) return;
+  root.innerHTML = "";
+  const items = buildCharacterOverviewChangeTimelineItems(payload?.character || "");
+  items.forEach((item) => {
+    const card = document.createElement("article");
+    card.className = "character-overview-change-item";
+    card.innerHTML = `
+      <div class="character-overview-change-item-head">
+        <strong>${item.title}</strong>
+        <small>${item.updated}</small>
+      </div>
+      <p>${item.copy}</p>
+      <span>${item.badge}</span>
+    `;
+    root.appendChild(card);
+  });
+  root.classList.toggle("hidden", root.childElementCount === 0);
+  toggle("character-overview-change-timeline-empty", root.childElementCount === 0);
 }
 
 function buildCharacterOverviewHealthSnapshot(fields) {

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -67,6 +67,10 @@ function setWorkOverviewLoading(loading, message = "") {
   if (progressRoot) {
     progressRoot.classList.toggle("is-loading-work", Boolean(loading));
   }
+  const loadingRoot = el("work-overview-loading");
+  if (loadingRoot) {
+    loadingRoot.classList.toggle("hidden", !loading);
+  }
   if (loading) {
     setText("detail-action-note", message || "正在载入这一卷...", "");
     toggle("detail-action-note", true);
@@ -636,8 +640,8 @@ function renderWorkSessionPreview(run) {
     const button = document.createElement("button");
     button.type = "button";
     const snippet = getSessionPreviewSnippet(item);
-    const matchedCharacter = findMatchedSessionCharacter(snippet, characterNames);
-    button.className = `work-session-card${matchedCharacter ? " has-match" : ""}`;
+    const matchInfo = findMatchedSessionCharacter(snippet, characterNames);
+    button.className = `work-session-card${matchInfo.character ? " has-match" : ""}`;
     const participantCount = Array.isArray(item.participants) ? item.participants.length : 0;
     button.innerHTML = `
       <div class="work-session-head">
@@ -646,7 +650,7 @@ function renderWorkSessionPreview(run) {
           <small>${item.mode_display || humanizeMode(item.mode) || "这一幕"} · ${participantCount || 0} 人</small>
         </div>
       </div>
-      ${matchedCharacter ? `<span class="work-session-match">命中 ${escapeHtml(matchedCharacter)}</span>` : ""}
+      ${matchInfo.character ? `<span class="work-session-match">命中 ${escapeHtml(matchInfo.character)} · ${escapeHtml(matchInfo.reason)}</span>` : ""}
       ${snippet ? `<p class="work-session-copy">${escapeHtml(snippet)}</p>` : ""}
       <div class="work-session-meta">
         <span>${formatWeakTime(item.updated_at) || "刚刚"}</span>
@@ -675,11 +679,12 @@ function getSessionPreviewSnippet(item) {
 
 function findMatchedSessionCharacter(snippet, characterNames) {
   const text = String(snippet || "").trim();
-  if (!text) return "";
-  return (Array.isArray(characterNames) ? characterNames : []).find((name) => {
+  if (!text) return { character: "", reason: "" };
+  const matched = (Array.isArray(characterNames) ? characterNames : []).find((name) => {
     const candidate = String(name || "").trim();
     return candidate && text.includes(candidate);
   }) || "";
+  return matched ? { character: matched, reason: "摘要提到" } : { character: "", reason: "" };
 }
 
 async function openWorkSessionFromPreviewItem(item) {

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -596,13 +596,14 @@ function setWorkGraphStatusBadge(text, tone = "warning") {
 
 function renderWorkSessionPreview(run) {
   const root = el("work-session-preview");
+  const toggleButton = el("work-session-preview-toggle");
   if (!root) return;
   root.innerHTML = "";
   const novelTitle = runNovelTitle(run);
-  const sessions = (recentSessionsCache || [])
-    .filter((item) => normalizeNovelTitle(item?.novel_id || "") === novelTitle)
-    .slice(0, 3);
-  sessions.forEach((item) => {
+  const allSessions = (recentSessionsCache || []).filter((item) => normalizeNovelTitle(item?.novel_id || "") === novelTitle);
+  const canExpand = allSessions.length > 3;
+  const visibleSessions = workSessionPreviewExpanded ? allSessions : allSessions.slice(0, 3);
+  visibleSessions.forEach((item) => {
     const button = document.createElement("button");
     button.type = "button";
     button.className = "work-session-card";
@@ -637,6 +638,10 @@ function renderWorkSessionPreview(run) {
     });
     root.appendChild(button);
   });
+  if (toggleButton) {
+    toggleButton.classList.toggle("hidden", !canExpand);
+    toggleButton.textContent = workSessionPreviewExpanded ? "收起部分" : "展开全部";
+  }
   root.classList.toggle("hidden", root.childElementCount === 0);
   toggle("work-session-preview-empty", root.childElementCount === 0);
 }
@@ -1563,6 +1568,7 @@ function renderRun(run, options = {}) {
   redistillPanelOpen = false;
   sourceHistoryExpanded = false;
   characterReadinessExpanded = false;
+  workSessionPreviewExpanded = false;
   runCreationPending = run.status === "running" && run.summary?.status_text !== "workflow_complete";
   renderRunSummary(run);
   renderRunEvents(run);

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -628,6 +628,7 @@ function renderWorkSessionPreview(run) {
     button.type = "button";
     button.className = "work-session-card";
     const participantCount = Array.isArray(item.participants) ? item.participants.length : 0;
+    const snippet = readRecentSessionSnippet(item.run_id, item.session_id);
     button.innerHTML = `
       <div class="work-session-head">
         <div class="work-session-title">
@@ -635,6 +636,7 @@ function renderWorkSessionPreview(run) {
           <small>${item.mode_display || humanizeMode(item.mode) || "这一幕"} · ${participantCount || 0} 人</small>
         </div>
       </div>
+      ${snippet ? `<p class="work-session-copy">${escapeHtml(snippet)}</p>` : ""}
       <div class="work-session-meta">
         <span>${formatWeakTime(item.updated_at) || "刚刚"}</span>
         <span>${humanizeSessionStatus(item.status)}</span>

--- a/src/web/static/js/workflow.js
+++ b/src/web/static/js/workflow.js
@@ -151,6 +151,11 @@ function resetDialogueView() {
   currentCharacterOverview = null;
   setSessionBadge("未启幕");
   if (el("dialogue-transcript")) el("dialogue-transcript").innerHTML = "";
+  const memoryRoot = el("dialogue-memory");
+  if (memoryRoot) {
+    memoryRoot.classList.add("is-collapsed");
+  }
+  toggle("dialogue-memory", false);
   if (el("dialogue-message")) el("dialogue-message").value = "";
   if (typeof syncSuggestButtonVisibility === "function") syncSuggestButtonVisibility(null);
   if (typeof renderObserveQuickReplies === "function") renderObserveQuickReplies(null);

--- a/src/web/static/styles/base.css
+++ b/src/web/static/styles/base.css
@@ -405,10 +405,10 @@ textarea {
 
 .experience-shell.dialogue-layout .library-rail {
   min-height: 0;
-  height: auto;
-  max-height: none;
-  grid-template-rows: auto auto;
-  overflow: visible;
+  height: 100%;
+  max-height: 100%;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
 }
 
 .experience-shell.dialogue-layout .studio-grid {
@@ -425,8 +425,10 @@ textarea {
 }
 
 .experience-shell.dialogue-layout .rail-sessions {
-  max-height: none;
-  align-self: start;
+  min-height: 0;
+  height: 100%;
+  max-height: 100%;
+  align-self: stretch;
 }
 
 .experience-shell.dialogue-layout .chat-shell,

--- a/src/web/static/styles/base.css
+++ b/src/web/static/styles/base.css
@@ -345,9 +345,9 @@ textarea {
 .experience-shell.dialogue-layout {
   grid-template-columns: 13.6rem minmax(0, 1fr);
   gap: 1rem;
-  align-items: start;
-  min-height: 0;
-  height: auto;
+  align-items: stretch;
+  min-height: var(--dialogue-rail-height);
+  height: var(--dialogue-rail-height);
 }
 
 .experience-shell.dialogue-layout > .app-shell {
@@ -360,9 +360,9 @@ textarea {
   grid-row: 1;
   min-width: 0;
   min-height: 0;
-  height: auto;
+  height: 100%;
   max-height: none;
-  align-self: start;
+  align-self: stretch;
 }
 
 .experience-shell.dialogue-layout.sidebar-collapsed {
@@ -375,8 +375,8 @@ textarea {
   min-width: 13.6rem;
   min-height: 0;
   max-height: none;
-  height: auto;
-  align-self: start;
+  height: 100%;
+  align-self: stretch;
 }
 
 .page-shell:has(.experience-shell.dialogue-layout) {
@@ -416,9 +416,9 @@ textarea {
 }
 
 .experience-shell.dialogue-layout #main-shell-root > .main-shell {
-  min-height: var(--dialogue-rail-height);
-  height: var(--dialogue-rail-height);
-  max-height: var(--dialogue-rail-height);
+  min-height: 100%;
+  height: 100%;
+  max-height: none;
   grid-template-rows: minmax(0, 1fr) auto;
   overflow: hidden;
   align-content: stretch;

--- a/src/web/static/styles/dialogue.css
+++ b/src/web/static/styles/dialogue.css
@@ -29,10 +29,119 @@
   height: 100%;
   min-height: 0;
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   border-radius: 32px;
   background: linear-gradient(180deg, rgba(255, 252, 248, 0.86), rgba(255, 248, 243, 0.76));
   box-shadow: var(--shadow);
   overflow: hidden;
+}
+
+.dialogue-memory {
+  display: grid;
+  gap: 0.62rem;
+  padding: 0.95rem clamp(0.95rem, 2.4vw, 1.4rem) 0.72rem;
+  border-bottom: 1px solid rgba(170, 146, 127, 0.14);
+  background: rgba(255, 252, 247, 0.88);
+}
+
+.dialogue-memory.is-collapsed {
+  gap: 0.2rem;
+  padding-bottom: 0.55rem;
+}
+
+.dialogue-memory-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.dialogue-memory-head-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.52rem;
+}
+
+.dialogue-memory-head strong {
+  color: var(--ink);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  font-weight: 600;
+}
+
+#dialogue-memory-copy-button {
+  min-height: 1.65rem;
+  padding: 0 0.58rem;
+  font-size: 0.68rem;
+}
+
+#dialogue-memory-toggle-button {
+  min-height: 1.65rem;
+  padding: 0 0.58rem;
+  font-size: 0.68rem;
+}
+
+.dialogue-memory-head small,
+.dialogue-memory-meta {
+  color: var(--ink-faint);
+  font-size: 0.68rem;
+  line-height: 1.45;
+}
+
+.dialogue-memory-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.52rem;
+}
+
+.dialogue-memory-body {
+  display: grid;
+  gap: 0.52rem;
+}
+
+.dialogue-memory.is-collapsed .dialogue-memory-body {
+  display: none;
+}
+
+.dialogue-memory-card {
+  display: grid;
+  gap: 0.28rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 12px;
+  border: 1px solid rgba(170, 146, 127, 0.12);
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.dialogue-memory-card span {
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+
+.dialogue-memory-card p {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.73rem;
+  line-height: 1.58;
+}
+
+.dialogue-memory-meta {
+  padding-left: 0.1rem;
+}
+
+.dialogue-memory-copy-status {
+  color: var(--accent-strong);
+  min-height: 1rem;
+}
+
+.dialogue-memory-mode {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.35rem;
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  background: rgba(184, 132, 113, 0.11);
+  color: var(--accent-strong);
 }
 
 .transcript {

--- a/src/web/static/styles/dialogue.css
+++ b/src/web/static/styles/dialogue.css
@@ -1,15 +1,17 @@
 .chat-shell {
   min-height: 0;
-  overflow: visible;
+  height: 100%;
+  overflow: hidden;
   width: 100%;
   max-width: 100%;
   min-width: 0;
+  display: grid;
 }
 
 .chat-empty,
 .chat-detail {
   min-height: 0;
-  height: auto;
+  height: 100%;
 }
 
 .chat-empty {
@@ -19,12 +21,14 @@
 }
 
 .chat-detail {
-  min-height: 26rem;
+  min-height: 0;
+  display: grid;
 }
 
 .chat-content {
-  height: auto;
-  min-height: 26rem;
+  height: 100%;
+  min-height: 0;
+  display: grid;
   border-radius: 32px;
   background: linear-gradient(180deg, rgba(255, 252, 248, 0.86), rgba(255, 248, 243, 0.76));
   box-shadow: var(--shadow);
@@ -32,8 +36,9 @@
 }
 
 .transcript {
-  max-height: min(62vh, 46rem);
-  min-height: 26rem;
+  max-height: none;
+  min-height: 0;
+  height: 100%;
   overflow: auto;
   display: grid;
   gap: 18px;

--- a/src/web/static/styles/responsive.css
+++ b/src/web/static/styles/responsive.css
@@ -48,6 +48,10 @@
     overflow: visible;
   }
 
+  .experience-shell.dialogue-layout .chat-shell {
+    display: block;
+  }
+
   .library-rail {
     grid-template-rows: auto;
     width: 100%;
@@ -90,6 +94,7 @@
     padding: 24px 16px 20px;
     max-height: min(56vh, 32rem);
     min-height: 18rem;
+    height: auto;
   }
 
   .chat-detail {

--- a/src/web/static/styles/responsive.css
+++ b/src/web/static/styles/responsive.css
@@ -80,7 +80,9 @@
   .studio-grid,
   .mini-grid,
   .choice-deck,
-  .info-row {
+  .info-row,
+  .work-loading-grid,
+  .work-loading-grid-2 {
     grid-template-columns: 1fr;
   }
 

--- a/src/web/static/styles/responsive.css
+++ b/src/web/static/styles/responsive.css
@@ -59,6 +59,20 @@
     max-height: none;
   }
 
+  .experience-shell.dialogue-layout .library-rail {
+    grid-template-rows: auto;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .experience-shell.dialogue-layout .rail-sessions {
+    height: auto;
+    max-height: none;
+    min-height: 0;
+    align-self: auto;
+  }
+
   .app-shell.sidebar-collapsed .library-rail {
     display: none;
   }

--- a/src/web/static/styles/responsive.css
+++ b/src/web/static/styles/responsive.css
@@ -113,6 +113,14 @@
     height: auto;
   }
 
+  .dialogue-memory {
+    padding: 0.78rem 0.86rem 0.62rem;
+  }
+
+  .dialogue-memory-grid {
+    grid-template-columns: 1fr;
+  }
+
   .chat-detail {
     min-height: 20rem;
   }

--- a/src/web/static/styles/workspace.css
+++ b/src/web/static/styles/workspace.css
@@ -421,10 +421,22 @@
 }
 
 .work-overview-grid {
-  display: grid;
-  grid-template-columns: minmax(18rem, 1fr) minmax(18rem, 0.95fr) minmax(20rem, 1.08fr);
+  display: flex;
   gap: 0.9rem;
-  align-items: start;
+  align-items: flex-start;
+}
+
+.work-overview-grid > .work-overview-panel:nth-child(1) {
+  flex: 1 1 31%;
+}
+
+.work-overview-grid > .work-overview-panel:nth-child(2) {
+  flex: 0.95 1 31%;
+}
+
+.work-overview-grid > .work-overview-panel:nth-child(3) {
+  flex: 1.08 1 38%;
+  min-width: 20rem;
 }
 
 .work-overview-panel {
@@ -1926,11 +1938,22 @@ textarea::placeholder {
   }
 
   .work-progress-strip,
-  .work-overview-grid,
   .work-summary-grid,
   .character-overview-grid,
   .character-overview-fields {
     grid-template-columns: 1fr;
+  }
+
+  .work-overview-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .work-overview-grid > .work-overview-panel:nth-child(1),
+  .work-overview-grid > .work-overview-panel:nth-child(2),
+  .work-overview-grid > .work-overview-panel:nth-child(3) {
+    flex: initial;
+    min-width: 0;
   }
 
   .quality-grid {

--- a/src/web/static/styles/workspace.css
+++ b/src/web/static/styles/workspace.css
@@ -626,6 +626,14 @@
   line-height: 1.55;
 }
 
+.work-session-copy {
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .work-character-meta,
 .work-session-meta {
   display: flex;

--- a/src/web/static/styles/workspace.css
+++ b/src/web/static/styles/workspace.css
@@ -980,6 +980,58 @@
   font-size: 0.68rem;
 }
 
+.character-overview-change-timeline {
+  display: grid;
+  gap: 0.56rem;
+}
+
+.character-overview-change-item {
+  display: grid;
+  gap: 0.26rem;
+  padding: 0.78rem 0.86rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(170, 146, 127, 0.1);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.character-overview-change-item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.character-overview-change-item-head strong {
+  color: var(--ink);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.character-overview-change-item-head small,
+.character-overview-change-item p,
+.character-overview-change-item span {
+  color: var(--ink-faint);
+  font-size: 0.69rem;
+  line-height: 1.56;
+}
+
+.character-overview-change-item p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.character-overview-change-item span {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 1.25rem;
+  padding: 0 0.46rem;
+  border-radius: 999px;
+  background: rgba(184, 132, 113, 0.1);
+  color: var(--accent-strong);
+}
+
 .character-overview-grid {
   display: grid;
   grid-template-columns: 1.1fr 0.9fr;

--- a/src/web/static/styles/workspace.css
+++ b/src/web/static/styles/workspace.css
@@ -319,6 +319,56 @@
   padding-top: 0.15rem;
 }
 
+.work-overview-loading {
+  display: grid;
+  gap: 0.8rem;
+  padding: 0.1rem 0;
+}
+
+.work-loading-line {
+  height: 0.92rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(230, 223, 217, 0.8), rgba(245, 240, 235, 0.98), rgba(230, 223, 217, 0.8));
+  background-size: 200% 100%;
+  animation: work-loading-sheen 1.5s ease-in-out infinite;
+}
+
+.work-loading-line-lg {
+  width: min(20rem, 72%);
+  height: 1.1rem;
+}
+
+.work-loading-grid,
+.work-loading-grid-2 {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.work-loading-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.work-loading-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.work-loading-card {
+  min-height: 8rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(90deg, rgba(232, 226, 220, 0.72), rgba(248, 244, 240, 0.96), rgba(232, 226, 220, 0.72));
+  background-size: 200% 100%;
+  animation: work-loading-sheen 1.5s ease-in-out infinite;
+}
+
+@keyframes work-loading-sheen {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
 .work-overview-hero {
   display: grid;
   gap: 0.95rem;

--- a/src/web/static/styles/workspace.css
+++ b/src/web/static/styles/workspace.css
@@ -1411,6 +1411,10 @@
   pointer-events: none;
 }
 
+#step-progress.is-loading-work > :not(#detail-action-note):not(#work-overview-loading) {
+  display: none !important;
+}
+
 .detail-section-timeline .timeline {
   margin-top: 0.15rem;
   max-height: min(16.5rem, 34vh);

--- a/src/web/static/styles/workspace.css
+++ b/src/web/static/styles/workspace.css
@@ -634,6 +634,19 @@
   overflow: hidden;
 }
 
+.work-session-match {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 1.35rem;
+  padding: 0 0.5rem;
+  border-radius: 999px;
+  background: rgba(184, 132, 113, 0.12);
+  color: var(--accent-strong);
+  font-size: 0.65rem;
+  line-height: 1;
+}
+
 .work-character-meta,
 .work-session-meta {
   display: flex;
@@ -676,6 +689,11 @@
     border-color 180ms ease,
     background 180ms ease,
     box-shadow 180ms ease;
+}
+
+.work-session-card.has-match {
+  border-color: rgba(184, 132, 113, 0.22);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(250, 241, 235, 0.86));
 }
 
 .work-session-card:hover {

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -2696,6 +2696,12 @@ class WebAppRouteTests(unittest.TestCase):
             self.assertEqual(completed["transcript"][0]["role"], "scene")
             self.assertEqual(completed["transcript"][1]["role"], "user")
             self.assertEqual(completed["transcript"][2]["role"], "character")
+            memory_summary = completed.get("session_memory_summary", {})
+            self.assertEqual(memory_summary.get("mode"), "insert")
+            self.assertIn("最近一拍", memory_summary.get("recap", ""))
+            self.assertIn("当前主要在场", memory_summary.get("cast", ""))
+            self.assertIn("你以", memory_summary.get("perspective", ""))
+            self.assertTrue(memory_summary.get("world"))
 
 @unittest.skipUnless(TestClient and create_app, "fastapi test client is unavailable")
 class WebAppRouteTests(unittest.TestCase):

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -2875,6 +2875,9 @@ class WebAppRouteTests(unittest.TestCase):
             sessions_response = client.get("/api/web/sessions")
             self.assertEqual(sessions_response.status_code, 200)
             self.assertEqual(len(sessions_response.json()["items"]), 1)
+            first = sessions_response.json()["items"][0]
+            self.assertIn("last_entry_preview", first)
+            self.assertTrue(str(first["last_entry_preview"]).strip())
 
     def test_delete_dialogue_session_route_removes_session(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 背景

这一轮继续补齐 Work/Character/Session 的产品化闭环，重点解决两个体验问题：

1. 会话里“本局记忆”虽然有价值，但常驻占位过大。  
2. 复制摘要按钮反馈不清晰，用户会感觉“点了没反应”。  

同时补上人物资产“可追溯性”缺口：让角色页能直接看到最近改动轨迹。

---

## 本次改动

### 1) 会话页：本局记忆可折叠 + 默认折叠
- 新增折叠按钮（展开/收起）
- 默认进入会话时折叠，减少首屏占位
- 切换/重置会话后回到折叠态

### 2) 会话页：复制摘要稳定可用
- 复制逻辑优先使用 `navigator.clipboard.writeText`
- 增加 `execCommand('copy')` 回退路径，兼容不支持 Clipboard API 的场景
- 增加明确状态反馈（已复制 / 复制失败），不再“无反应”

### 3) 会话数据：后端提供统一记忆摘要
- `DialogueService` 序列化会话时新增 `session_memory_summary`
- 包含：
  - `mode` / `mode_display`
  - `recap`
  - `cast`
  - `perspective`
  - `world`
  - `updated_at`
- 前端优先读取该摘要渲染；无数据时再回退前端本地推断

### 4) 人物页：新增改动时间线
- 新增“改动时间线”区块
- 基于现有 run events（`persona_review_saved`）渲染最近改动记录
- 区分 AI 补全与手动保存，展示字段标签与时间提示，增强资产可追溯性

### 5) 响应式与样式细化
- 会话记忆区与移动端布局联动
- 小屏下保持可滚动与紧凑展示，不挤压主对话区域

---

## 影响文件

- `src/web/chat/service.py`
- `src/web/static/fragments/main-shell.html`
- `src/web/static/fragments/workflow-strip.html`
- `src/web/static/js/dialogue.js`
- `src/web/static/js/main.js`
- `src/web/static/js/run-detail.js`
- `src/web/static/js/workflow.js`
- `src/web/static/styles/dialogue.css`
- `src/web/static/styles/responsive.css`
- `src/web/static/styles/workspace.css`
- `tests/test_web_app.py`

---

## 验证

已执行并通过：

- `pytest tests/test_web_app.py -k "dialogue_session_prepare_and_ingest or dialogue_routes_roundtrip or dialogue_reply_route_generates_and_ingests" -q`
- `pytest tests/test_web_app.py -k "persona_review_route_accepts_extended_fields or recent_sessions_route_lists_created_sessions" -q`
- `pytest tests/test_web_asset_version.py -q`

---

## 结果

- 会话首屏更干净，记忆能力仍可一键展开查看  
- 复制摘要行为可感知、可确认  
- 角色页改动轨迹更清晰，资产“被如何写稳”的路径可回看  
