### PR TITLE
feat: 对话上下文增强与关系动态演化（含关系图可视化编辑）

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -103,6 +103,15 @@ class Config:
             "min_reply_relevance": 4,
             "llm_history_messages": 8,
         },
+        "memory": {
+            "recent_turns": 24,
+            "summary_char_limit": 360,
+            "long_term_max_entries": 400,
+            "vector_provider": "local",
+            "pinecone_api_key": "",
+            "pinecone_index": "",
+            "pinecone_namespace": "zaomeng",
+        },
         "paths": {
             "characters": "data/characters",
             "relations": "data/relations",

--- a/src/core/relation_store.py
+++ b/src/core/relation_store.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 from src.core.contracts import PathProviderLike, RelationStore
 from src.utils.file_utils import load_markdown_data, save_markdown_data
@@ -40,3 +41,108 @@ class MarkdownRelationStore(RelationStore):
                 f"- relation_count: {len(relations)}",
             ],
         )
+
+    def apply_dialogue_update(
+        self,
+        novel_id: str,
+        *,
+        pair_key: str,
+        message: str,
+        speaker: str = "",
+        target: str = "",
+    ) -> Dict[str, Any]:
+        payload = self.load_relations(novel_id, default={"novel_id": novel_id, "relations": {}}) or {}
+        relations = dict(payload.get("relations", {}) or {})
+        current = dict(relations.get(pair_key, {}) or {})
+
+        metrics = self._coerce_metrics(current)
+        msg = str(message or "")
+        positive_tokens: Sequence[str] = ("谢谢", "抱歉", "理解", "关心", "在意", "帮你", "信你", "一起")
+        negative_tokens: Sequence[str] = ("滚", "讨厌", "厌恶", "闭嘴", "烦", "背叛", "威胁", "恨")
+        uncertain_tokens: Sequence[str] = ("也许", "或许", "未必", "以后再说", "再看", "不一定")
+
+        if any(token in msg for token in positive_tokens):
+            metrics["trust"] = min(10, metrics["trust"] + 1)
+            metrics["affection"] = min(10, metrics["affection"] + 1)
+            metrics["hostility"] = max(0, metrics["hostility"] - 1)
+        if any(token in msg for token in negative_tokens):
+            metrics["hostility"] = min(10, metrics["hostility"] + 2)
+            metrics["trust"] = max(0, metrics["trust"] - 1)
+            metrics["affection"] = max(0, metrics["affection"] - 2)
+        if any(token in msg for token in uncertain_tokens):
+            metrics["ambiguity"] = min(10, metrics["ambiguity"] + 1)
+
+        current.update(metrics)
+        current.setdefault("evidence_lines", [])
+        evidence_lines = current.get("evidence_lines", [])
+        if not isinstance(evidence_lines, list):
+            evidence_lines = []
+        evidence_line = f"{speaker}->{target}: {msg}".strip(": ").strip()
+        if evidence_line:
+            evidence_lines.append(evidence_line[:220])
+        current["evidence_lines"] = evidence_lines[-10:]
+
+        current["updated_at"] = int(time.time())
+        relations[pair_key] = current
+        payload["relations"] = relations
+        payload["novel_id"] = novel_id
+        payload["conflicts"] = self.detect_conflicts(relations)
+        save_markdown_data(
+            self.path_provider.relations_file(novel_id),
+            payload,
+            title="RELATION_GRAPH",
+            summary=[
+                f"- novel_id: {novel_id}",
+                f"- relation_count: {len(relations)}",
+                f"- conflict_count: {len(payload.get('conflicts', []))}",
+            ],
+        )
+        return current
+
+    def detect_conflicts(self, relations: Dict[str, Dict[str, Any]]) -> list[Dict[str, Any]]:
+        conflicts: list[Dict[str, Any]] = []
+        for pair_key, relation in relations.items():
+            if not isinstance(relation, dict):
+                continue
+            metrics = self._coerce_metrics(relation)
+            trust = metrics["trust"]
+            affection = metrics["affection"]
+            hostility = metrics["hostility"]
+            ambiguity = metrics["ambiguity"]
+
+            tags: list[str] = []
+            if trust >= 8 and hostility >= 6:
+                tags.append("high_trust_high_hostility")
+            if affection >= 8 and hostility >= 6:
+                tags.append("high_affection_high_hostility")
+            if ambiguity >= 8 and max(trust, affection, hostility) >= 8:
+                tags.append("high_ambiguity_with_extreme_signal")
+            if not tags:
+                continue
+            conflicts.append(
+                {
+                    "pair_key": pair_key,
+                    "tags": tags,
+                    "trust": trust,
+                    "affection": affection,
+                    "hostility": hostility,
+                    "ambiguity": ambiguity,
+                }
+            )
+        return conflicts
+
+    @staticmethod
+    def _coerce_metrics(relation: Dict[str, Any]) -> Dict[str, int]:
+        def to_int(key: str, default: int) -> int:
+            try:
+                value = int(relation.get(key, default))
+            except (TypeError, ValueError):
+                value = default
+            return max(0, min(10, value))
+
+        return {
+            "trust": to_int("trust", 5),
+            "affection": to_int("affection", 5),
+            "hostility": to_int("hostility", 0),
+            "ambiguity": to_int("ambiguity", 3),
+        }

--- a/src/core/session_store.py
+++ b/src/core/session_store.py
@@ -3,10 +3,46 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import math
+import re
+import time
+from collections import Counter
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from src.core.contracts import PathProviderLike, SessionStore
 from src.utils.file_utils import load_markdown_data, save_markdown_data
+
+
+def _now_ts() -> int:
+    return int(time.time())
+
+
+def _normalize_text(value: Any) -> str:
+    text = str(value or "").strip()
+    return re.sub(r"\s+", " ", text)
+
+
+def _extract_tokens(text: str) -> list[str]:
+    lowered = text.lower()
+    return re.findall(r"[0-9a-z\u4e00-\u9fff]{2,}", lowered)
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, int(value)))
+
+
+@dataclass
+class MemorySearchHit:
+    text: str
+    score: float
+    metadata: Dict[str, Any]
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload = {"text": self.text, "score": round(float(self.score), 6)}
+        payload.update(dict(self.metadata or {}))
+        return payload
 
 
 class MarkdownSessionStore(SessionStore):
@@ -14,6 +50,7 @@ class MarkdownSessionStore(SessionStore):
 
     def __init__(self, path_provider: PathProviderLike):
         self.path_provider = path_provider
+        self._local_vector_dimensions = 256
 
     def load_session(self, session_id: str, default: Any = None) -> Any:
         return load_markdown_data(self._session_path(session_id), default=default)
@@ -29,6 +66,123 @@ class MarkdownSessionStore(SessionStore):
                 f"- mode: {session.get('mode', '')}",
             ],
         )
+
+    def compress_context(
+        self,
+        session: Dict[str, Any],
+        *,
+        max_recent_turns: Optional[int] = None,
+        summary_char_limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        history = list(session.get("history", []) or [])
+        if not history:
+            return session
+
+        cfg = self._memory_config()
+        recent_turns = _clamp(max_recent_turns or cfg["recent_turns"], 4, 200)
+        summary_limit = _clamp(summary_char_limit or cfg["summary_char_limit"], 80, 2000)
+        if len(history) <= recent_turns:
+            return session
+
+        to_archive = history[:-recent_turns]
+        keep = history[-recent_turns:]
+        state = session.setdefault("state", {})
+        memory_summary = dict(state.get("memory_summary", {}) or {})
+        previous_summary = _normalize_text(memory_summary.get("summary", ""))
+        compressed = self._build_memory_summary(previous_summary, to_archive, summary_limit)
+        key_points = self._extract_key_points(to_archive, limit=8)
+
+        state["memory_summary"] = {
+            "summary": compressed,
+            "key_points": key_points,
+            "compressed_turns": len(to_archive),
+            "recent_turns_kept": len(keep),
+            "updated_at": _now_ts(),
+        }
+        session["history"] = keep
+
+        session_id = str(session.get("id", "")).strip()
+        if session_id:
+            for entry in to_archive:
+                text = self._entry_to_memory_text(entry)
+                if not text:
+                    continue
+                metadata = {
+                    "speaker": str(entry.get("speaker", "")).strip(),
+                    "target": str(entry.get("target", "")).strip(),
+                    "ts": int(entry.get("ts", 0) or 0),
+                }
+                self.append_long_term_memory(session_id, text, metadata=metadata)
+        return session
+
+    def append_long_term_memory(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        normalized = _normalize_text(text)
+        if not session_id or not normalized:
+            return
+        memory_payload = self._load_long_term_payload(session_id)
+        entries = list(memory_payload.get("entries", []) or [])
+        item = {
+            "id": f"mem-{_now_ts()}-{len(entries) + 1}",
+            "text": normalized,
+            "metadata": dict(metadata or {}),
+            "vector": self._embed_local(normalized),
+        }
+        entries.append(item)
+        max_entries = _clamp(int(self._memory_config().get("long_term_max_entries", 400) or 400), 20, 5000)
+        if len(entries) > max_entries:
+            entries = entries[-max_entries:]
+        memory_payload["entries"] = entries
+        memory_payload["session_id"] = session_id
+        memory_payload["updated_at"] = _now_ts()
+        save_markdown_data(
+            self._long_term_memory_path(session_id),
+            memory_payload,
+            title="SESSION_LONG_TERM_MEMORY",
+            summary=[
+                f"- session_id: {session_id}",
+                f"- entry_count: {len(entries)}",
+            ],
+        )
+        self._upsert_pinecone_vector(session_id, item)
+
+    def search_long_term_memory(self, session_id: str, query: str, *, top_k: int = 5) -> List[Dict[str, Any]]:
+        normalized = _normalize_text(query)
+        if not session_id or not normalized:
+            return []
+        limit = _clamp(top_k, 1, 50)
+        pinecone_hits = self._search_pinecone(session_id, normalized, top_k=limit)
+        if pinecone_hits:
+            return [hit.to_payload() for hit in pinecone_hits]
+
+        payload = self._load_long_term_payload(session_id)
+        entries = list(payload.get("entries", []) or [])
+        if not entries:
+            return []
+        query_vec = self._embed_local(normalized)
+        scored: list[MemorySearchHit] = []
+        for item in entries:
+            text = _normalize_text(item.get("text", ""))
+            if not text:
+                continue
+            item_vec = item.get("vector")
+            if not isinstance(item_vec, list) or not item_vec:
+                item_vec = self._embed_local(text)
+            score = self._cosine_similarity(query_vec, item_vec)
+            scored.append(
+                MemorySearchHit(
+                    text=text,
+                    score=score,
+                    metadata=dict(item.get("metadata", {}) or {}),
+                )
+            )
+        scored.sort(key=lambda hit: hit.score, reverse=True)
+        return [hit.to_payload() for hit in scored[:limit]]
 
     def save_relation_snapshot(self, session: Dict[str, Any]) -> None:
         payload = {
@@ -53,3 +207,205 @@ class MarkdownSessionStore(SessionStore):
 
     def _relation_snapshot_path(self, session_id: str):
         return self.path_provider.sessions_dir() / f"{session_id}_relations.md"
+
+    def _long_term_memory_path(self, session_id: str):
+        return self.path_provider.sessions_dir() / f"{session_id}_memory.md"
+
+    def _load_long_term_payload(self, session_id: str) -> Dict[str, Any]:
+        return load_markdown_data(
+            self._long_term_memory_path(session_id),
+            default={"session_id": session_id, "entries": [], "updated_at": 0},
+        ) or {"session_id": session_id, "entries": [], "updated_at": 0}
+
+    def _memory_config(self) -> Dict[str, Any]:
+        config = getattr(self.path_provider, "config", None)
+        get = getattr(config, "get", None)
+        if not callable(get):
+            return {
+                "recent_turns": 24,
+                "summary_char_limit": 360,
+                "long_term_max_entries": 400,
+                "vector_provider": "local",
+                "pinecone_api_key": "",
+                "pinecone_index": "",
+                "pinecone_namespace": "zaomeng",
+            }
+        return {
+            "recent_turns": int(get("memory.recent_turns", 24) or 24),
+            "summary_char_limit": int(get("memory.summary_char_limit", 360) or 360),
+            "long_term_max_entries": int(get("memory.long_term_max_entries", 400) or 400),
+            "vector_provider": str(get("memory.vector_provider", "local") or "local").strip().lower(),
+            "pinecone_api_key": str(get("memory.pinecone_api_key", "") or "").strip(),
+            "pinecone_index": str(get("memory.pinecone_index", "") or "").strip(),
+            "pinecone_namespace": str(get("memory.pinecone_namespace", "zaomeng") or "zaomeng").strip() or "zaomeng",
+        }
+
+    def _entry_to_memory_text(self, entry: Dict[str, Any]) -> str:
+        speaker = str(entry.get("speaker", "")).strip()
+        message = _normalize_text(entry.get("message", ""))
+        target = str(entry.get("target", "")).strip()
+        if not message:
+            return ""
+        if speaker and target:
+            return f"{speaker} -> {target}: {message}"
+        if speaker:
+            return f"{speaker}: {message}"
+        return message
+
+    def _build_memory_summary(
+        self,
+        previous_summary: str,
+        archived_entries: Sequence[Dict[str, Any]],
+        summary_char_limit: int,
+    ) -> str:
+        snippets = [self._entry_to_memory_text(entry) for entry in archived_entries]
+        snippets = [item for item in snippets if item]
+        head = "；".join(snippets[:4])
+        tail = "；".join(snippets[-4:])
+        candidate = f"{previous_summary}；{head}；{tail}" if previous_summary else f"{head}；{tail}"
+        condensed = re.sub(r"(；){2,}", "；", candidate).strip("； ")
+        if len(condensed) <= summary_char_limit:
+            return condensed
+        return f"{condensed[:summary_char_limit].rstrip()}..."
+
+    def _extract_key_points(self, archived_entries: Sequence[Dict[str, Any]], *, limit: int) -> List[str]:
+        points: list[str] = []
+        for entry in archived_entries:
+            text = self._entry_to_memory_text(entry)
+            if not text:
+                continue
+            normalized = text.strip()
+            if normalized and normalized not in points:
+                points.append(normalized)
+            if len(points) >= limit:
+                break
+        return points[:limit]
+
+    def _embed_local(self, text: str) -> List[float]:
+        vec = [0.0] * self._local_vector_dimensions
+        counts = Counter(_extract_tokens(text))
+        if not counts:
+            return vec
+        for token, weight in counts.items():
+            slot = hash(token) % self._local_vector_dimensions
+            vec[slot] += float(weight)
+        norm = math.sqrt(sum(value * value for value in vec))
+        if norm <= 0:
+            return vec
+        return [value / norm for value in vec]
+
+    @staticmethod
+    def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+        if not left or not right:
+            return 0.0
+        size = min(len(left), len(right))
+        dot = 0.0
+        left_norm = 0.0
+        right_norm = 0.0
+        for idx in range(size):
+            lv = float(left[idx])
+            rv = float(right[idx])
+            dot += lv * rv
+            left_norm += lv * lv
+            right_norm += rv * rv
+        if left_norm <= 0 or right_norm <= 0:
+            return 0.0
+        return dot / math.sqrt(left_norm * right_norm)
+
+    def _pinecone_client(self) -> Tuple[Any, str, str] | None:
+        cfg = self._memory_config()
+        provider = cfg["vector_provider"]
+        if provider not in {"pinecone", "pinecone-local-first"}:
+            return None
+        api_key = cfg["pinecone_api_key"]
+        index_name = cfg["pinecone_index"]
+        namespace = cfg["pinecone_namespace"]
+        if not api_key or not index_name:
+            return None
+        try:
+            pinecone_module = import_module("pinecone")
+        except Exception:
+            return None
+
+        client = None
+        index = None
+        try:
+            pinecone_cls = getattr(pinecone_module, "Pinecone", None)
+            if pinecone_cls is not None:
+                client = pinecone_cls(api_key=api_key)
+                index = client.Index(index_name)
+            else:
+                init = getattr(pinecone_module, "init", None)
+                index_factory = getattr(pinecone_module, "Index", None)
+                if callable(init) and callable(index_factory):
+                    init(api_key=api_key)
+                    index = index_factory(index_name)
+        except Exception:
+            return None
+        if index is None:
+            return None
+        return index, namespace, index_name
+
+    def _upsert_pinecone_vector(self, session_id: str, item: Dict[str, Any]) -> None:
+        pinecone = self._pinecone_client()
+        if pinecone is None:
+            return
+        index, namespace, _ = pinecone
+        vector = item.get("vector")
+        if not isinstance(vector, list) or not vector:
+            return
+        metadata = dict(item.get("metadata", {}) or {})
+        metadata["text"] = str(item.get("text", ""))[:2000]
+        metadata["session_id"] = session_id
+        try:
+            index.upsert(
+                vectors=[
+                    {
+                        "id": str(item.get("id", "")),
+                        "values": [float(value) for value in vector],
+                        "metadata": metadata,
+                    }
+                ],
+                namespace=namespace,
+            )
+        except Exception:
+            return
+
+    def _search_pinecone(self, session_id: str, query: str, *, top_k: int) -> List[MemorySearchHit]:
+        pinecone = self._pinecone_client()
+        if pinecone is None:
+            return []
+        index, namespace, _ = pinecone
+        try:
+            response = index.query(
+                vector=self._embed_local(query),
+                top_k=top_k,
+                include_metadata=True,
+                namespace=namespace,
+                filter={"session_id": {"$eq": session_id}},
+            )
+        except Exception:
+            return []
+
+        matches = getattr(response, "matches", None)
+        if matches is None and isinstance(response, dict):
+            matches = response.get("matches", [])
+        results: list[MemorySearchHit] = []
+        for item in matches or []:
+            metadata = getattr(item, "metadata", None)
+            score = getattr(item, "score", None)
+            if isinstance(item, dict):
+                metadata = item.get("metadata", metadata)
+                score = item.get("score", score)
+            metadata_payload = dict(metadata or {})
+            text = _normalize_text(metadata_payload.pop("text", ""))
+            if not text:
+                continue
+            results.append(
+                MemorySearchHit(
+                    text=text,
+                    score=float(score or 0.0),
+                    metadata=metadata_payload,
+                )
+            )
+        return results

--- a/src/modules/chat_engine.py
+++ b/src/modules/chat_engine.py
@@ -881,6 +881,9 @@ class ChatEngine:
         latest = session["history"][-6:]
         emotion = session["state"]["emotion"]
         relation_matrix = session["state"].setdefault("relation_matrix", {})
+        seen_keys = session["state"].setdefault("_processed_history_keys", [])
+        seen = set(str(item) for item in seen_keys if item)
+        touched: List[str] = []
         for item in latest:
             speaker = item["speaker"]
             if speaker in self.SYSTEM_SPEAKERS:
@@ -888,6 +891,12 @@ class ChatEngine:
 
             delta = 0
             msg = item["message"]
+            ts = int(item.get("ts", 0) or 0)
+            dedupe_key = f"{speaker}|{msg}|{ts}"
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            touched.append(dedupe_key)
             if any(k in msg for k in ("！", "怒", "生气", "质问")):
                 delta += 1
             if any(k in msg for k in ("冷静", "平静", "慢慢说", "理解")):
@@ -919,9 +928,32 @@ class ChatEngine:
                 "hostility": state["hostility"],
                 "ambiguity": state["ambiguity"],
             }
+            novel_id = str(session.get("novel_id", "")).strip()
+            if novel_id and hasattr(self.relation_store, "apply_dialogue_update"):
+                try:
+                    self.relation_store.apply_dialogue_update(
+                        novel_id,
+                        pair_key=key,
+                        message=msg,
+                        speaker=speaker,
+                        target=target,
+                    )
+                except Exception as exc:
+                    self.logger.debug("relation evolution skipped: %s", exc)
+        if touched:
+            session["state"]["_processed_history_keys"] = (list(seen_keys) + touched)[-240:]
 
     def _save_session(self, session: Dict[str, Any]) -> None:
         session["updated_at"] = int(time.time())
+        if hasattr(self.session_store, "compress_context"):
+            try:
+                self.session_store.compress_context(
+                    session,
+                    max_recent_turns=int(self.config.get("memory.recent_turns", 24) or 24),
+                    summary_char_limit=int(self.config.get("memory.summary_char_limit", 360) or 360),
+                )
+            except Exception as exc:
+                self.logger.debug("session context compression skipped: %s", exc)
         self.session_store.save_session(session)
         self._save_relation_snapshot(session)
 

--- a/src/web/api/routes/runs.py
+++ b/src/web/api/routes/runs.py
@@ -14,6 +14,7 @@ from src.web.api.schemas import (
     RestartRunRequest,
     SavePersonaReviewRequest,
     SuggestPersonaFieldRequest,
+    UpdateRelationDetailRequest,
 )
 from src.web.workflow import WebRunService
 
@@ -155,6 +156,21 @@ def list_relation_details(run_id: str, run_service: WebRunService = Depends(get_
         return run_service.list_relation_details(run_id)
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Relation graph not found.") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.patch("/api/web/runs/{run_id}/relations/{pair_key}")
+def update_relation_details(
+    run_id: str,
+    pair_key: str,
+    payload: UpdateRelationDetailRequest,
+    run_service: WebRunService = Depends(get_run_service),
+) -> dict[str, Any]:
+    try:
+        return run_service.update_relation_detail(run_id, pair_key, model_to_dict(payload))
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Relation pair not found.") from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/web/api/schemas.py
+++ b/src/web/api/schemas.py
@@ -86,6 +86,17 @@ class SuggestPersonaFieldRequest(BaseModel):
     field: str = Field(..., min_length=1)
 
 
+class UpdateRelationDetailRequest(BaseModel):
+    trust: int | None = Field(default=None, ge=0, le=10)
+    affection: int | None = Field(default=None, ge=0, le=10)
+    hostility: int | None = Field(default=None, ge=0, le=10)
+    ambiguity: int | None = Field(default=None, ge=0, le=10)
+    relationship_type: str = Field(default="")
+    relation_change: str = Field(default="")
+    conflict_point: str = Field(default="")
+    typical_interaction: str = Field(default="")
+
+
 class CreateDialogueSessionRequest(BaseModel):
     mode: str = Field(...)
     participants: list[str] = Field(default_factory=list)

--- a/src/web/artifacts/__init__.py
+++ b/src/web/artifacts/__init__.py
@@ -23,6 +23,7 @@ from .operations import (
     ingest_relation_result,
     list_relation_details,
     resolve_run_file,
+    update_relation_detail,
 )
 
 __all__ = [
@@ -44,5 +45,6 @@ __all__ = [
     "resolve_relations_file",
     "resolve_run_file",
     "split_relation_pair",
+    "update_relation_detail",
     "write_persona_profile",
 ]

--- a/src/web/artifacts/operations.py
+++ b/src/web/artifacts/operations.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Dict
 
 from src.utils.file_utils import safe_filename
 from src.web.artifacts.ingest import decode_text_content
@@ -107,6 +108,7 @@ def list_relation_details(
     coerce_relation_evidence: Callable[[dict[str, Any]], list[str]],
 ) -> dict[str, Any]:
     relations = dict(payload.get("relations", {}) or {})
+    conflicts = list(payload.get("conflicts", []) or [])
     items: list[dict[str, Any]] = []
     for pair_key, relation in sorted(relations.items()):
         if not isinstance(relation, dict):
@@ -123,16 +125,68 @@ def list_relation_details(
                 "relation_change": str(relation.get("relation_change", "")).strip(),
                 "conflict_point": str(relation.get("conflict_point", "")).strip(),
                 "typical_interaction": str(relation.get("typical_interaction", "")).strip(),
+                "ambiguity": int(relation.get("ambiguity", 3) or 3),
                 "evidence_lines": coerce_relation_evidence(relation),
             }
         )
+    conflict_map = {}
+    for item in conflicts:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("pair_key", "")).strip()
+        if not key:
+            continue
+        conflict_map[key] = item
     return {
         "run_id": run_id,
         "novel_id": str(manifest.get("novel_id", "")).strip(),
         "relations_file": str(relations_file.resolve()),
         "relation_count": len(items),
+        "conflict_count": len(conflict_map),
+        "conflicts": list(conflict_map.values()),
         "items": items,
     }
+
+
+def update_relation_detail(
+    *,
+    run_id: str,
+    manifest: dict[str, Any],
+    relations_file: Path,
+    payload: dict[str, Any],
+    pair_key: str,
+    updates: dict[str, Any],
+    save_relations: Callable[[Path, dict[str, Any]], None],
+    detect_conflicts: Callable[[Dict[str, Dict[str, Any]]], list[Dict[str, Any]]],
+) -> dict[str, Any]:
+    novel_id = str(manifest.get("novel_id", "")).strip() or run_id
+    relations = dict(payload.get("relations", {}) or {})
+    if pair_key not in relations or not isinstance(relations.get(pair_key), dict):
+        raise FileNotFoundError(pair_key)
+
+    relation = dict(relations[pair_key])
+    metric_fields = ("trust", "affection", "hostility", "ambiguity")
+    text_fields = ("relationship_type", "relation_change", "conflict_point", "typical_interaction")
+    for field in metric_fields:
+        if field not in updates:
+            continue
+        try:
+            relation[field] = max(0, min(10, int(updates.get(field, relation.get(field, 0)))))
+        except (TypeError, ValueError):
+            continue
+    for field in text_fields:
+        if field not in updates:
+            continue
+        relation[field] = str(updates.get(field, relation.get(field, "")) or "").strip()
+    relation["updated_at"] = int(time.time())
+    relations[pair_key] = relation
+
+    updated_payload = dict(payload)
+    updated_payload["novel_id"] = novel_id
+    updated_payload["relations"] = relations
+    updated_payload["conflicts"] = detect_conflicts(relations)
+    save_relations(relations_file, updated_payload)
+    return updated_payload
 
 
 def resolve_run_file(*, runs_root: Path, run_id: str, relative_path: str) -> Path:

--- a/src/web/chat/entrypoints.py
+++ b/src/web/chat/entrypoints.py
@@ -18,6 +18,8 @@ def create_dialogue_session_payload(
     load_pending_turn_payload: Callable[[str, str], dict[str, Any]],
     generate_dialogue_responses: Callable[[str, dict[str, Any]], list[dict[str, str]]],
     friendly_dialogue_llm_error: Callable[[Exception], str],
+    remember_long_term_memory: Callable[[str, str, str, str], None],
+    evolve_relations_from_turn: Callable[[str, dict[str, Any], list[dict[str, str]]], None],
 ) -> dict[str, Any]:
     session = dialogue.create_session(
         manifest,
@@ -40,11 +42,14 @@ def create_dialogue_session_payload(
         responses = generate_dialogue_responses(run_id, pending_payload)
     except LLMRequestError as exc:
         raise ValueError(friendly_dialogue_llm_error(exc)) from exc
-    return dialogue.ingest_turn_responses(
+    evolve_relations_from_turn(run_id, pending_payload, responses)
+    ingested = dialogue.ingest_turn_responses(
         run_id,
         session_id=session_id,
         responses=responses,
     )
+    remember_long_term_memory(run_id, session_id, opening_message, "narration")
+    return ingested
 
 
 def reply_dialogue_turn_payload(
@@ -58,6 +63,8 @@ def reply_dialogue_turn_payload(
     load_pending_turn_payload: Callable[[str, str], dict[str, Any]],
     generate_dialogue_responses: Callable[[str, dict[str, Any]], list[dict[str, str]]],
     friendly_dialogue_llm_error: Callable[[Exception], str],
+    remember_long_term_memory: Callable[[str, str, str, str], None],
+    evolve_relations_from_turn: Callable[[str, dict[str, Any], list[dict[str, str]]], None],
 ) -> dict[str, Any]:
     speaker_override = "场景提示" if str(message_kind or "").strip() == "narration" else ""
     dialogue.prepare_turn(
@@ -72,7 +79,10 @@ def reply_dialogue_turn_payload(
         responses = generate_dialogue_responses(run_id, pending_payload)
     except LLMRequestError as exc:
         raise ValueError(friendly_dialogue_llm_error(exc)) from exc
-    return dialogue.ingest_turn_responses(run_id, session_id=session_id, responses=responses)
+    evolve_relations_from_turn(run_id, pending_payload, responses)
+    ingested = dialogue.ingest_turn_responses(run_id, session_id=session_id, responses=responses)
+    remember_long_term_memory(run_id, session_id, message, message_kind)
+    return ingested
 
 
 def suggest_dialogue_turn_payload(

--- a/src/web/chat/service.py
+++ b/src/web/chat/service.py
@@ -11,6 +11,9 @@ from typing import Any
 from uuid import uuid4
 
 from src.web.artifacts.ingest import load_profile_source
+from src.core.config import Config
+from src.core.path_provider import PathProvider
+from src.core.session_store import MarkdownSessionStore
 
 
 def _utc_now() -> str:
@@ -46,6 +49,7 @@ class DialogueService:
 
     def __init__(self, runs_root: str | Path) -> None:
         self.runs_root = Path(runs_root)
+        self._memory_store: MarkdownSessionStore | None = None
 
     def list_sessions(self, run_id: str) -> list[dict[str, Any]]:
         root = self._sessions_root(run_id)
@@ -738,6 +742,18 @@ class DialogueService:
         elif cast_speakers:
             relation = f"本局关键人物：{'、'.join(cast_speakers[:4])}"
 
+        session_id = str(session.get("session_id", "")).strip()
+        semantic_hint = ""
+        if session_id and self._ensure_memory_store():
+            try:
+                hits = self._memory_store.search_long_term_memory(session_id, "关系 冲突 目标", top_k=1)
+            except Exception:
+                hits = []
+            if hits:
+                semantic_hint = str((hits[0] or {}).get("text", "")).strip()
+        if semantic_hint:
+            relation = f"{relation} · 长期记忆：{self._trim_summary_text(semantic_hint, 68)}"
+
         return {
             "mode": mode,
             "mode_display": mode_display,
@@ -748,6 +764,18 @@ class DialogueService:
             "world": world,
             "updated_at": str(session.get("updated_at", "")).strip(),
         }
+
+    def _ensure_memory_store(self) -> bool:
+        if self._memory_store is not None:
+            return True
+        try:
+            config = Config()
+            config.update({"paths": {"sessions": str(self.runs_root / "__session_memory_cache")}})
+            self._memory_store = MarkdownSessionStore(PathProvider(config))
+            return True
+        except Exception:
+            self._memory_store = None
+            return False
 
     @staticmethod
     def _trim_summary_text(value: str, limit: int) -> str:

--- a/src/web/service_facades/artifacts.py
+++ b/src/web/service_facades/artifacts.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.utils.file_utils import save_markdown_data
 from src.web.artifacts import (
     export_relations_source,
     load_profile_source,
@@ -20,6 +21,7 @@ from src.web.artifacts import (
     split_relation_pair,
 )
 from src.web.artifacts import list_relation_details as build_relation_details_payload
+from src.web.artifacts import update_relation_detail as apply_relation_detail_update
 from src.web.artifacts import (
     ingest_character_result as apply_character_ingest,
     ingest_relation_result as apply_relation_ingest,
@@ -170,9 +172,72 @@ class ArtifactServiceMixin:
             coerce_relation_evidence=coerce_relation_evidence,
         )
 
+    def update_relation_detail(self, run_id: str, pair_key: str, updates: dict[str, Any]) -> dict[str, Any]:
+        manifest = self._require_manifest(run_id)
+        relations_file = resolve_relations_file(manifest)
+        payload = load_relations_source(relations_file)
+        refreshed_payload = apply_relation_detail_update(
+            run_id=run_id,
+            manifest=manifest,
+            relations_file=relations_file,
+            payload=payload,
+            pair_key=pair_key,
+            updates=updates,
+            save_relations=lambda path, data: save_markdown_data(
+                path,
+                data,
+                title="RELATION_GRAPH",
+                summary=[
+                    f"- novel_id: {data.get('novel_id', '')}",
+                    f"- relation_count: {len(dict(data.get('relations', {}) or {}))}",
+                    f"- conflict_count: {len(list(data.get('conflicts', []) or []))}",
+                ],
+            ),
+            detect_conflicts=self._detect_relation_conflicts,
+        )
+        return build_relation_details_payload(
+            run_id=run_id,
+            manifest=manifest,
+            relations_file=relations_file,
+            payload=refreshed_payload,
+            split_relation_pair=split_relation_pair,
+            relation_type_label=relation_type_label,
+            coerce_relation_evidence=coerce_relation_evidence,
+        )
+
     def resolve_run_file(self, run_id: str, relative_path: str) -> Path:
         return resolve_run_file(
             runs_root=self.runs_root,
             run_id=run_id,
             relative_path=relative_path,
         )
+
+    @staticmethod
+    def _detect_relation_conflicts(relations: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+        conflicts: list[dict[str, Any]] = []
+        for pair_key, relation in (relations or {}).items():
+            if not isinstance(relation, dict):
+                continue
+            trust = int(relation.get("trust", 5) or 5)
+            affection = int(relation.get("affection", 5) or 5)
+            hostility = int(relation.get("hostility", 0) or 0)
+            ambiguity = int(relation.get("ambiguity", 3) or 3)
+            tags = []
+            if trust >= 8 and hostility >= 6:
+                tags.append("high_trust_high_hostility")
+            if affection >= 8 and hostility >= 6:
+                tags.append("high_affection_high_hostility")
+            if ambiguity >= 8 and max(trust, affection, hostility) >= 8:
+                tags.append("high_ambiguity_with_extreme_signal")
+            if tags:
+                conflicts.append(
+                    {
+                        "pair_key": pair_key,
+                        "tags": tags,
+                        "trust": trust,
+                        "affection": affection,
+                        "hostility": hostility,
+                        "ambiguity": ambiguity,
+                    }
+                )
+        return conflicts

--- a/src/web/service_facades/dialogue.py
+++ b/src/web/service_facades/dialogue.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
+from src.utils.file_utils import save_markdown_data
+from src.web.artifacts.ingest import load_relations_source
 from src.web.chat import (
     build_dialogue_llm_messages,
     build_dialogue_suggestion_llm_messages,
@@ -66,6 +69,8 @@ class DialogueServiceMixin:
             load_pending_turn_payload=self._load_pending_turn_payload,
             generate_dialogue_responses=self._generate_dialogue_responses,
             friendly_dialogue_llm_error=friendly_dialogue_llm_error,
+            remember_long_term_memory=self._remember_dialogue_long_term_memory,
+            evolve_relations_from_turn=self._evolve_relations_from_turn,
         )
 
     def get_dialogue_session(self, run_id: str, session_id: str) -> dict[str, Any]:
@@ -111,6 +116,8 @@ class DialogueServiceMixin:
             load_pending_turn_payload=self._load_pending_turn_payload,
             generate_dialogue_responses=self._generate_dialogue_responses,
             friendly_dialogue_llm_error=friendly_dialogue_llm_error,
+            remember_long_term_memory=self._remember_dialogue_long_term_memory,
+            evolve_relations_from_turn=self._evolve_relations_from_turn,
         )
 
     def suggest_dialogue_turn(self, run_id: str, *, session_id: str, seed_text: str = "") -> dict[str, str]:
@@ -199,3 +206,131 @@ class DialogueServiceMixin:
     @staticmethod
     def _parse_dialogue_suggestion(content: str) -> str:
         return parse_dialogue_suggestion(content)
+
+    def _remember_dialogue_long_term_memory(
+        self,
+        run_id: str,
+        session_id: str,
+        message: str,
+        message_kind: str,
+    ) -> None:
+        if not message:
+            return
+        try:
+            config = self._build_runtime_config_for_run(run_dir=self.runs_root / run_id)
+            parts = self._build_runtime_parts(config)
+            text = str(message).strip()
+            prefix = "[剧情推动]" if str(message_kind or "").strip() == "narration" else "[对话]"
+            parts.session_store.append_long_term_memory(session_id, f"{prefix} {text}", metadata={"run_id": run_id})
+        except Exception:
+            return
+
+    def _evolve_relations_from_turn(
+        self,
+        run_id: str,
+        pending_payload: dict[str, Any],
+        responses: list[dict[str, str]],
+    ) -> None:
+        if not responses:
+            return
+        try:
+            manifest = self._require_manifest(run_id)
+            relation_graph = dict(manifest.get("artifact_index", {}).get("relation_graph", {}) or {})
+            relation_path = Path(str(relation_graph.get("relations_file", "")).strip())
+            if not relation_path.exists():
+                return
+            relation_payload = load_relations_source(relation_path)
+            relations = dict(relation_payload.get("relations", {}) or {})
+            input_block = dict(pending_payload.get("input", {}) or {})
+            speaker = str(input_block.get("speaker", "")).strip()
+            participants = [str(item).strip() for item in input_block.get("participants", []) if str(item).strip()]
+            active = [str(item).strip() for item in input_block.get("active_participants", []) if str(item).strip()]
+            candidates = active or participants
+
+            def pair_key(a: str, b: str) -> str:
+                return "_".join(sorted([a, b]))
+
+            for reply in responses:
+                responder = str(reply.get("speaker", "")).strip()
+                message = str(reply.get("message", "")).strip()
+                if not responder or not message:
+                    continue
+                target = speaker
+                if not target or target in {"User", "场景提示", "旁白"}:
+                    pool = [name for name in candidates if name and name != responder]
+                    target = pool[0] if pool else ""
+                if not target or target == responder:
+                    continue
+                key = pair_key(responder, target)
+                relation = dict(relations.get(key, {}) or {})
+                trust = int(relation.get("trust", 5) or 5)
+                affection = int(relation.get("affection", 5) or 5)
+                hostility = int(relation.get("hostility", 0) or 0)
+                ambiguity = int(relation.get("ambiguity", 3) or 3)
+                if any(token in message for token in ("谢谢", "抱歉", "理解", "关心", "在意", "一起")):
+                    trust = min(10, trust + 1)
+                    affection = min(10, affection + 1)
+                    hostility = max(0, hostility - 1)
+                if any(token in message for token in ("滚", "讨厌", "厌恶", "闭嘴", "烦", "恨", "威胁")):
+                    hostility = min(10, hostility + 2)
+                    trust = max(0, trust - 1)
+                    affection = max(0, affection - 2)
+                if any(token in message for token in ("也许", "或许", "未必", "再说")):
+                    ambiguity = min(10, ambiguity + 1)
+
+                relation.update(
+                    {
+                        "trust": trust,
+                        "affection": affection,
+                        "hostility": hostility,
+                        "ambiguity": ambiguity,
+                    }
+                )
+                evidence_lines = relation.get("evidence_lines", [])
+                if not isinstance(evidence_lines, list):
+                    evidence_lines = []
+                evidence_lines.append(f"{responder}->{target}: {message}"[:220])
+                relation["evidence_lines"] = evidence_lines[-10:]
+                relations[key] = relation
+
+            conflict_list = []
+            for key, relation in relations.items():
+                if not isinstance(relation, dict):
+                    continue
+                trust = int(relation.get("trust", 5) or 5)
+                affection = int(relation.get("affection", 5) or 5)
+                hostility = int(relation.get("hostility", 0) or 0)
+                ambiguity = int(relation.get("ambiguity", 3) or 3)
+                tags = []
+                if trust >= 8 and hostility >= 6:
+                    tags.append("high_trust_high_hostility")
+                if affection >= 8 and hostility >= 6:
+                    tags.append("high_affection_high_hostility")
+                if ambiguity >= 8 and max(trust, affection, hostility) >= 8:
+                    tags.append("high_ambiguity_with_extreme_signal")
+                if tags:
+                    conflict_list.append(
+                        {
+                            "pair_key": key,
+                            "tags": tags,
+                            "trust": trust,
+                            "affection": affection,
+                            "hostility": hostility,
+                            "ambiguity": ambiguity,
+                        }
+                    )
+            relation_payload["relations"] = relations
+            relation_payload["conflicts"] = conflict_list
+            relation_payload["novel_id"] = str(manifest.get("novel_id", "")).strip() or run_id
+            save_markdown_data(
+                relation_path,
+                relation_payload,
+                title="RELATION_GRAPH",
+                summary=[
+                    f"- novel_id: {relation_payload['novel_id']}",
+                    f"- relation_count: {len(relations)}",
+                    f"- conflict_count: {len(conflict_list)}",
+                ],
+            )
+        except Exception:
+            return

--- a/src/web/static/js/run-detail.js
+++ b/src/web/static/js/run-detail.js
@@ -2131,25 +2131,74 @@ function renderRelationDetails(payload) {
   const root = el("relation-details-list");
   if (!root) return;
   root.innerHTML = "";
+  const conflictMap = new Map(
+    (payload?.conflicts || [])
+      .filter((item) => item?.pair_key)
+      .map((item) => [item.pair_key, item])
+  );
   (payload?.items || []).forEach((item) => {
     const card = document.createElement("article");
     card.className = "relation-detail-card";
+    const conflict = conflictMap.get(item.pair_key);
+    const conflictLabel = conflict?.tags?.length ? ` · 冲突：${conflict.tags.join(", ")}` : "";
     card.innerHTML = `
       <div class="relation-detail-head">
         <strong>${joinCharacters(item.characters || []) || item.pair_key || "未命名关系"}</strong>
-        <span class="relation-detail-type">${item.relationship_type || "牵连"}</span>
+        <span class="relation-detail-type">${item.relationship_type || "牵连"}${conflictLabel}</span>
       </div>
-      <div class="relation-detail-metrics">信 ${item.trust} · 情 ${item.affection} · 冲 ${item.hostility}</div>
-      <div class="relation-detail-copy">
-        <p>${item.typical_interaction || "关系摘要暂未生成。"}</p>
-        ${item.conflict_point ? `<p>冲突点：${item.conflict_point}</p>` : ""}
-        ${item.relation_change ? `<p>变化：${item.relation_change}</p>` : ""}
+      <div class="relation-detail-edit-grid">
+        <label>信 <input type="number" data-field="trust" min="0" max="10" value="${Number(item.trust || 0)}" /></label>
+        <label>情 <input type="number" data-field="affection" min="0" max="10" value="${Number(item.affection || 0)}" /></label>
+        <label>冲 <input type="number" data-field="hostility" min="0" max="10" value="${Number(item.hostility || 0)}" /></label>
+        <label>疑 <input type="number" data-field="ambiguity" min="0" max="10" value="${Number(item.ambiguity || 3)}" /></label>
+      </div>
+      <div class="relation-detail-copy relation-detail-edit-text">
+        <label>关系类型<input type="text" data-field="relationship_type" value="${escapeHtml(item.relationship_type || "牵连")}" /></label>
+        <label>互动摘要<textarea data-field="typical_interaction" rows="2">${escapeHtml(item.typical_interaction || "")}</textarea></label>
+        <label>冲突点<textarea data-field="conflict_point" rows="2">${escapeHtml(item.conflict_point || "")}</textarea></label>
+        <label>关系变化<textarea data-field="relation_change" rows="2">${escapeHtml(item.relation_change || "")}</textarea></label>
+      </div>
+      <div class="relation-detail-actions">
+        <button type="button" class="soft-button" data-action="save-relation" data-pair-key="${escapeHtml(item.pair_key || "")}">保存</button>
       </div>
       <div class="relation-detail-evidence">
         <p>证据句</p>
         <ul>${(item.evidence_lines || []).map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul>
       </div>
     `;
+    const saveButton = card.querySelector('[data-action="save-relation"]');
+    if (saveButton instanceof HTMLButtonElement) {
+      saveButton.addEventListener("click", async () => {
+        if (!currentRunId) return;
+        const pairKey = saveButton.dataset.pairKey || "";
+        if (!pairKey) return;
+        const body = {};
+        card.querySelectorAll("[data-field]").forEach((node) => {
+          if (!(node instanceof HTMLInputElement || node instanceof HTMLTextAreaElement)) return;
+          const field = node.dataset.field || "";
+          if (!field) return;
+          body[field] = node.value;
+        });
+        saveButton.disabled = true;
+        setStatus("relation-details-status", "正在保存关系修改...");
+        try {
+          const refreshed = await apiJson(
+            `/api/web/runs/${currentRunId}/relations/${encodeURIComponent(pairKey)}`,
+            {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            },
+            "关系保存失败。"
+          );
+          renderRelationDetails(refreshed);
+          setStatus("relation-details-status", "关系已保存。");
+        } catch (error) {
+          saveButton.disabled = false;
+          setStatus("relation-details-status", error.message || "关系保存失败。");
+        }
+      });
+    }
     root.appendChild(card);
   });
   setStatus("relation-details-status", payload?.items?.length ? "" : "这张关系网暂时还没有明细。");

--- a/src/web/static/styles/modal.css
+++ b/src/web/static/styles/modal.css
@@ -100,6 +100,42 @@
   line-height: 1.65;
 }
 
+.relation-detail-edit-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.relation-detail-edit-grid label,
+.relation-detail-edit-text label {
+  display: grid;
+  gap: 0.2rem;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+}
+
+.relation-detail-edit-grid input,
+.relation-detail-edit-text input,
+.relation-detail-edit-text textarea {
+  border: 1px solid rgba(170, 146, 127, 0.18);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--ink);
+  padding: 0.38rem 0.5rem;
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.relation-detail-edit-text {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.relation-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .relation-detail-copy p,
 .relation-detail-evidence p {
   margin: 0;

--- a/tests/test_relation_store.py
+++ b/tests/test_relation_store.py
@@ -36,6 +36,36 @@ class RelationStoreTests(unittest.TestCase):
             self.assertEqual(default_payload["relations"]["刘备_关羽"]["trust"], 9)
             self.assertEqual(exported_payload["relations"]["刘备_关羽"]["affection"], 8)
 
+    def test_relation_store_supports_dynamic_update_and_conflict_detection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = Config()
+            config.update({"paths": {"relations": str(root / "relations")}})
+            store = MarkdownRelationStore(PathProvider(config))
+            relations = {
+                "林黛玉_贾宝玉": {
+                    "trust": 8,
+                    "affection": 8,
+                    "hostility": 2,
+                    "ambiguity": 3,
+                }
+            }
+            store.save_relations("hongloumeng", relations)
+
+            updated = store.apply_dialogue_update(
+                "hongloumeng",
+                pair_key="林黛玉_贾宝玉",
+                message="我理解你，但我也恨你这么轻慢。",
+                speaker="林黛玉",
+                target="贾宝玉",
+            )
+            self.assertIn("trust", updated)
+            self.assertIn("hostility", updated)
+
+            payload = store.load_relations("hongloumeng", default={})
+            self.assertIn("conflicts", payload)
+            self.assertIsInstance(payload.get("conflicts", []), list)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -41,6 +41,36 @@ class SessionStoreTests(unittest.TestCase):
             self.assertEqual(loaded_snapshot["relation_matrix"]["关羽_刘备"]["trust"], 9)
             self.assertEqual(loaded_snapshot["relation_delta"]["关羽_刘备"]["trust"], 10)
 
+    def test_session_store_compresses_context_and_supports_long_term_search(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = Config()
+            config.update({"paths": {"sessions": str(root / "sessions")}})
+            store = MarkdownSessionStore(PathProvider(config))
+            session = {
+                "id": "mem123",
+                "novel_id": "hongloumeng",
+                "mode": "observe",
+                "history": [
+                    {"speaker": "林黛玉", "message": f"第{i}句提到了宝玉和心事。", "ts": i}
+                    for i in range(32)
+                ],
+                "state": {},
+            }
+
+            updated = store.compress_context(session)
+            self.assertLess(len(updated["history"]), 32)
+            memory_summary = updated.get("state", {}).get("memory_summary", {})
+            self.assertTrue(memory_summary.get("summary"))
+            self.assertGreater(memory_summary.get("compressed_turns", 0), 0)
+
+            memory_payload = load_markdown_data(root / "sessions" / "mem123_memory.md", default={})
+            self.assertGreater(len(memory_payload.get("entries", [])), 0)
+
+            hits = store.search_long_term_memory("mem123", "宝玉 心事", top_k=3)
+            self.assertTrue(hits)
+            self.assertIn("text", hits[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -2636,6 +2636,50 @@ class WebAppRouteTests(unittest.TestCase):
                 (Path(tmp) / "runs" / payload["run_id"] / "artifacts" / "relations" / "hongloumeng_relations.html").exists()
             )
 
+    def test_relation_details_patch_updates_relation_and_conflicts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            service = WebRunService(tmp)
+            service.save_model_settings(
+                provider="openai-compatible",
+                model="deepseek-chat",
+                base_url="https://example.com/v1",
+                api_key="sk-test",
+            )
+            payload = service.create_run(
+                novel_name="hongloumeng.txt",
+                novel_content_base64=base64.b64encode("林黛玉见了贾宝玉。".encode("utf-8")).decode("ascii"),
+                characters=["林黛玉", "贾宝玉"],
+            )
+            relations_text = "\n".join(
+                [
+                    "- novel_id: hongloumeng",
+                    "## 林黛玉_贾宝玉",
+                    "- trust: 8",
+                    "- affection: 8",
+                    "- hostility: 1",
+                    "- relationship_type: 牵连",
+                    "- typical_interaction: 试探",
+                ]
+            )
+            service.ingest_relation_result(
+                payload["run_id"],
+                content_base64=base64.b64encode(relations_text.encode("utf-8")).decode("ascii"),
+                filename="hongloumeng_relations.md",
+            )
+            client = TestClient(create_app(service))
+            patched = client.patch(
+                f"/api/web/runs/{payload['run_id']}/relations/{'林黛玉_贾宝玉'}",
+                json={
+                    "hostility": 7,
+                    "relationship_type": "拉扯",
+                    "conflict_point": "真心反噬",
+                },
+            )
+            self.assertEqual(patched.status_code, 200)
+            data = patched.json()
+            self.assertEqual(data["items"][0]["relationship_type"], "拉扯")
+            self.assertGreaterEqual(data["conflict_count"], 1)
+
     def test_dialogue_session_prepare_and_ingest(self):
         with tempfile.TemporaryDirectory() as tmp:
             service = WebRunService(tmp)


### PR DESCRIPTION
## 背景
本 PR 实现两项核心能力升级：

1. **对话上下文增强**（基于 `session_store.py`）
   - 增加上下文压缩，避免长对话历史拖垮可用上下文。
   - 增加长期记忆存储与检索能力。
   - 提供语义检索机制：默认本地向量检索，并支持可选 Pinecone 接入。

2. **关系动态演化**（扩展 `relation_store.py`）
   - 支持基于对话内容的关系强度实时更新（trust / affection / hostility / ambiguity）。
   - 增加冲突检测（如高信任+高敌意等冲突信号）。
   - 在 Web UI 里支持关系图明细直接编辑并保存。

---

## 主要改动

### 1) 会话记忆与上下文压缩
- `src/core/session_store.py`
  - 新增：
    - `compress_context(...)`
    - `append_long_term_memory(...)`
    - `search_long_term_memory(...)`
  - 引入长期记忆持久化文件（session 级）。
  - 本地向量语义检索（hash embedding + cosine）。
  - 可选 Pinecone upsert/query（配置启用时生效）。

- `src/core/config.py`
  - 新增 `memory` 配置段：
    - `recent_turns`
    - `summary_char_limit`
    - `long_term_max_entries`
    - `vector_provider`
    - `pinecone_api_key`
    - `pinecone_index`
    - `pinecone_namespace`

- `src/modules/chat_engine.py`
  - 在 `_save_session` 接入 `compress_context` 自动压缩。
  - 对关系演化处理增加去重键，避免同一历史重复计入。

### 2) 关系实时演化与冲突检测
- `src/core/relation_store.py`
  - 新增：
    - `apply_dialogue_update(...)`
    - `detect_conflicts(...)`
  - 支持关系分值自动更新与冲突列表写回。

- `src/web/service_facades/dialogue.py`
  - 在对话 reply 生成后，按当前 turn 自动演化关系并写回 relation payload。
  - 同步写入冲突检测结果。

### 3) Web 关系图可视化编辑
- `src/web/api/schemas.py`
  - 新增 `UpdateRelationDetailRequest`

- `src/web/api/routes/runs.py`
  - 新增接口：
    - `PATCH /api/web/runs/{run_id}/relations/{pair_key}`

- `src/web/artifacts/operations.py`
  - `list_relation_details` 返回增强（含 ambiguity/conflicts）
  - 新增 `update_relation_detail(...)`

- `src/web/service_facades/artifacts.py`
  - 新增 `update_relation_detail(...)`
  - 增加冲突检测与关系 payload 保存逻辑。

- `src/web/static/js/run-detail.js`
  - 关系明细卡改为可编辑（数值+文本字段）
  - 增加卡片级“保存”动作，调用 PATCH 接口
  - 显示冲突标签。

- `src/web/static/styles/modal.css`
  - 增加关系编辑区样式（输入框、网格、操作区）。

### 4) 对话入口接长期记忆
- `src/web/chat/entrypoints.py`
  - 在 create/reply 流程中增加：
    - 长期记忆写入 hook
    - 关系演化 hook

- `src/web/chat/service.py`
  - memory summary 构造中接入长期记忆语义检索提示（best effort）。

---

## 测试

新增/更新测试：
- `tests/test_session_store.py`
  - 覆盖上下文压缩与长期记忆语义检索。
- `tests/test_relation_store.py`
  - 覆盖关系动态更新与冲突检测。
- `tests/test_web_app.py`
  - 覆盖关系 PATCH 编辑接口与冲突回传。

本地执行（节选）：
- `pytest tests/test_session_store.py tests/test_relation_store.py` ✅
- `pytest tests/test_web_app.py -k "relation_details_patch_updates_relation_and_conflicts or dialogue_reply_route_generates_and_ingests or dialogue_routes_roundtrip"` ✅

---

## 兼容性说明
- 旧数据结构可继续读取。
- 新增字段（如 memory/conflicts/ambiguity）为向后兼容增强，不影响现有基础流程。
- Pinecone 为可选能力，未配置时自动回落本地检索。
